### PR TITLE
Add endpoint to list beamline detectors

### DIFF
--- a/src/nsls2api/models/beamlines.py
+++ b/src/nsls2api/models/beamlines.py
@@ -8,6 +8,20 @@ import pydantic
 class Detector(pydantic.BaseModel):
     name: str
 
+class DetectorView(pydantic.BaseModel):
+    detectors: list[Detector] | None = None
+    
+    class Settings:
+        projection = {
+            "detectors": "$detectors",
+        }
+
+
+class DetectorList(pydantic.BaseModel):
+    detectors: list[Detector] | None = None
+    count: int | None = None
+
+
 
 class BeamlineService(pydantic.BaseModel):
     name: str
@@ -17,7 +31,7 @@ class BeamlineService(pydantic.BaseModel):
 
 
 class ServicesOnly(pydantic.BaseModel):
-    services: list[BeamlineService]
+    services: list[BeamlineService] | None = None
 
     class Settings:
         projection = {
@@ -92,7 +106,7 @@ class DataRootDirectoryView(pydantic.BaseModel):
 
 class EndStation(pydantic.BaseModel):
     name: str
-    service_accounts: Optional[ServiceAccounts]
+    service_accounts: Optional[ServiceAccounts] = None
 
 
 class Beamline(beanie.Document):
@@ -104,13 +118,14 @@ class Beamline(beanie.Document):
     pass_name: Optional[str]
     pass_id: Optional[str]
     nsls2_redhat_satellite_location_name: Optional[str]
-    service_accounts: ServiceAccounts
+    service_accounts: ServiceAccounts | None = None
     endstations: Optional[list[EndStation]]
     data_admins: Optional[list[str]]
     github_org: Optional[str]
     ups_id: Optional[str]
     data_root: Optional[str] = None
-    services: Optional[list[BeamlineService]]
+    services: Optional[list[BeamlineService]] = []
+    detectors: Optional[list[Detector]] = []
     created_on: datetime.datetime = pydantic.Field(
         default_factory=datetime.datetime.now
     )

--- a/src/nsls2api/services/beamline_service.py
+++ b/src/nsls2api/services/beamline_service.py
@@ -5,6 +5,8 @@ from beanie.odm.operators.find.comparison import In
 
 from nsls2api.models.beamlines import (
     Beamline,
+    Detector,
+    DetectorView,
     ServicesOnly,
     ServiceAccounts,
     ServiceAccountsView,
@@ -44,6 +46,17 @@ async def all_services(name: str) -> Optional[ServicesOnly]:
         ServicesOnly
     )
     return beamline_services.services
+
+
+async def detectors(name: str) -> Optional[list[Detector]]:
+    detectors = await Beamline.find_one(Beamline.name == name.upper()).project(
+        DetectorView
+    )  
+    
+    if detectors is None:
+        return None
+    
+    return detectors.detectors
 
 
 async def service_accounts(name: str) -> Optional[ServiceAccounts]:


### PR DESCRIPTION
Added `beamline\{name}\detectors` endpoint to list detectors for a beamline.  This resolves #19 

The response is of the form 
```
{
  "detectors": [
    {
      "name": "detector1"
    },
    {
      "name": "detector2"
    }
  ],
  "count": 2
}
```

We can add more info about detectors as we want in the future