### PR TITLE
Catch Lookup errors for non-existant proposals

### DIFF
--- a/.github/workflows/test-production-deployment.yml
+++ b/.github/workflows/test-production-deployment.yml
@@ -2,10 +2,8 @@ name: Integration Tests for Deployed API
 
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '*/30 * * * *'
   workflow_dispatch:
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   integration_tests:

--- a/src/nsls2api/api/v1/proposal_api.py
+++ b/src/nsls2api/api/v1/proposal_api.py
@@ -168,10 +168,16 @@ async def get_proposal_usernames(proposal_id: int):
 
 @router.get("/proposal/{proposal_id}/directories")
 async def get_proposal_directories(proposal_id: int) -> ProposalDirectoriesList:
-    directories = await proposal_service.directories(proposal_id)
-    if directories is None:
+    try:
+        directories = await proposal_service.directories(proposal_id)
+        if directories is None:
+            return fastapi.responses.JSONResponse(
+                {"error": f"Directories not found for proposal {proposal_id}"},
+                status_code=404,
+            )
+    except LookupError as e:
         return fastapi.responses.JSONResponse(
-            {"error": f"Directories not found for proposal {proposal_id}"},
+            {"error": e.args[0]},
             status_code=404,
         )
 


### PR DESCRIPTION
I have also removed the workflow trigger on PR and reduced the frequency of the production endpoint testing. 