### PR TITLE
Add flag for Y/M/D tree creation

### DIFF
--- a/src/nsls2api/api/models/beamline_model.py
+++ b/src/nsls2api/api/models/beamline_model.py
@@ -1,1 +1,15 @@
 # This is for response models relating to the beamline api endpoints.
+
+from enum import Enum
+
+
+class AssetDirectoryGranularity(Enum):
+    """
+    Represents the granularity options for asset directory YYYY/MM/DD/HH tree structure.
+    The value specifies the most granular level to create directories for.
+    """
+
+    year = "year"
+    month = "month"
+    day = "day"
+    hour = "hour"

--- a/src/nsls2api/api/models/proposal_model.py
+++ b/src/nsls2api/api/models/proposal_model.py
@@ -4,6 +4,7 @@ from typing import Optional
 import pydantic
 
 from nsls2api.models.proposals import Proposal, User
+from nsls2api.api.models.beamline_model import AssetDirectoryGranularity
 
 
 class UsernamesList(pydantic.BaseModel):
@@ -62,6 +63,7 @@ class ProposalDirectories(pydantic.BaseModel):
     users: list[dict[str, str]]
     groups: list[dict[str, str]]
     create_ymd_directory_tree: bool | None = False
+    directory_most_granular_level: AssetDirectoryGranularity | None = None
 
     model_config = {
         "json_schema_extra": {
@@ -85,22 +87,26 @@ class ProposalDirectories(pydantic.BaseModel):
         }
     }
 
-# Not used - may remove 
+
+# Not used - may remove
 class ACL(pydantic.BaseModel):
     entity: str
     permissions: str
-    
-# Not used - may remove 
+
+
+# Not used - may remove
 class Directory(pydantic.BaseModel):
     path: str
     is_aboslute: bool
     owner: str
     group: str
-    acls: list[ACL] | None = []   
+    acls: list[ACL] | None = []
 
-# Not used - may remove 
+
+# Not used - may remove
 class ProposalDirectorySkeleton(pydantic.BaseModel):
     asset_directories: list[Directory]
+
 
 class ProposalDirectoriesList(pydantic.BaseModel):
     directory_count: int

--- a/src/nsls2api/api/models/proposal_model.py
+++ b/src/nsls2api/api/models/proposal_model.py
@@ -61,6 +61,7 @@ class ProposalDirectories(pydantic.BaseModel):
     cycle: str | None = None
     users: list[dict[str, str]]
     groups: list[dict[str, str]]
+    create_ymd_directory_tree: bool | None = False
 
     model_config = {
         "json_schema_extra": {

--- a/src/nsls2api/api/models/proposal_model.py
+++ b/src/nsls2api/api/models/proposal_model.py
@@ -62,7 +62,6 @@ class ProposalDirectories(pydantic.BaseModel):
     cycle: str | None = None
     users: list[dict[str, str]]
     groups: list[dict[str, str]]
-    create_ymd_directory_tree: bool | None = False
     directory_most_granular_level: AssetDirectoryGranularity | None = None
 
     model_config = {
@@ -74,6 +73,7 @@ class ProposalDirectories(pydantic.BaseModel):
                     "group": "xf31id1",
                     "beamline": "TST",
                     "cycle": "1066-1",
+                    "directory_most_granular_level": "month",
                     "users": [
                         {"name": "xf31id", "permissions": "rw"},
                         {"name": "service-account", "permissions": "rw"},

--- a/src/nsls2api/services/beamline_service.py
+++ b/src/nsls2api/services/beamline_service.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from beanie.odm.operators.find.comparison import In
 
+from nsls2api.api.models.beamline_model import AssetDirectoryGranularity
 from nsls2api.models.beamlines import (
     Beamline,
     Detector,
@@ -209,6 +210,7 @@ async def proposal_directory_skeleton(name: str):
                 "groups": groups_acl,
                 "beamline": name.upper(),
                 "create_ymd_directory_tree": True,
+                "directory_most_granular_level": AssetDirectoryGranularity.day,
             }
             directory_list.append(directory)
 
@@ -221,6 +223,7 @@ async def proposal_directory_skeleton(name: str):
         "groups": groups_acl,
         "beamline": name.upper(),
         "create_ymd_directory_tree": True,
+        "directory_most_granular_level": AssetDirectoryGranularity.day,
     }
     directory_list.append(default_directory)
 

--- a/src/nsls2api/services/beamline_service.py
+++ b/src/nsls2api/services/beamline_service.py
@@ -195,7 +195,6 @@ async def proposal_directory_skeleton(name: str):
         "users": users_acl,
         "groups": groups_acl,
         "beamline": name.upper(),
-        "create_ymd_directory_tree": False,
     }
     directory_list.append(asset_directory)
 

--- a/src/nsls2api/services/beamline_service.py
+++ b/src/nsls2api/services/beamline_service.py
@@ -208,7 +208,6 @@ async def proposal_directory_skeleton(name: str):
                 "users": users_acl,
                 "groups": groups_acl,
                 "beamline": name.upper(),
-                "create_ymd_directory_tree": True,
                 "directory_most_granular_level": AssetDirectoryGranularity.day,
             }
             directory_list.append(directory)
@@ -221,7 +220,6 @@ async def proposal_directory_skeleton(name: str):
         "users": users_acl,
         "groups": groups_acl,
         "beamline": name.upper(),
-        "create_ymd_directory_tree": True,
         "directory_most_granular_level": AssetDirectoryGranularity.day,
     }
     directory_list.append(default_directory)

--- a/src/nsls2api/services/beamline_service.py
+++ b/src/nsls2api/services/beamline_service.py
@@ -194,6 +194,7 @@ async def proposal_directory_skeleton(name: str):
         "users": users_acl,
         "groups": groups_acl,
         "beamline": name.upper(),
+        "create_ymd_directory_tree": False,
     }
     directory_list.append(asset_directory)
 
@@ -207,6 +208,7 @@ async def proposal_directory_skeleton(name: str):
                 "users": users_acl,
                 "groups": groups_acl,
                 "beamline": name.upper(),
+                "create_ymd_directory_tree": True,
             }
             directory_list.append(directory)
 
@@ -218,6 +220,7 @@ async def proposal_directory_skeleton(name: str):
         "users": users_acl,
         "groups": groups_acl,
         "beamline": name.upper(),
+        "create_ymd_directory_tree": True,
     }
     directory_list.append(default_directory)
 


### PR DESCRIPTION
I've added a field `create_ymd_directory_tree` which will globally default to `false` but is set to be `true` for detector (and default) directories.  

The new response from the API is in an attachment in a comment below.

resolves #32 