### PR TITLE
Add ability to define a custom dataadmins group/right

### DIFF
--- a/src/nsls2api/models/beamlines.py
+++ b/src/nsls2api/models/beamlines.py
@@ -122,6 +122,7 @@ class Beamline(beanie.Document):
     service_accounts: ServiceAccounts | None = None
     endstations: Optional[list[EndStation]]
     data_admins: Optional[list[str]]
+    custom_data_admin_group: Optional[str] = None
     github_org: Optional[str]
     ups_id: Optional[str]
     data_root: Optional[str] = None

--- a/src/nsls2api/services/beamline_service.py
+++ b/src/nsls2api/services/beamline_service.py
@@ -164,6 +164,15 @@ async def data_roles_by_user(username: str) -> Optional[list[str]]:
     return beamline_names
 
 
+async def custom_data_admin_group(name: str) -> str:
+    beamline = await Beamline.find_one(Beamline.name == name.upper())
+
+    if beamline.custom_data_admin_group is None:
+        return f"n2sn-right-dataadmin-{name.lower()}"
+    else:
+        return beamline.custom_data_admin_group
+
+
 async def proposal_directory_skeleton(name: str):
     detector_list = await detectors(name.upper())
 
@@ -183,8 +192,8 @@ async def proposal_directory_skeleton(name: str):
     users_acl.append({f"{service_usernames.workflow}": "r"})
     users_acl.append({"nsls2data": "r"})
 
-    groups_acl.append({f"n2sn-dataadmin-{name.lower()}": "r"})
-    groups_acl.append({"n2sn-dataadmin": "r"})
+    groups_acl.append({f"{await custom_data_admin_group(name)}": "r"})
+    groups_acl.append({"n2sn-right-dataadmin": "r"})
 
     # Add the asset directory so this has the same permissions as the detector directories
     # and not just inherit from the parent (i.e. proposal) directory.

--- a/src/nsls2api/services/proposal_service.py
+++ b/src/nsls2api/services/proposal_service.py
@@ -311,7 +311,7 @@ async def directories(proposal_id: int):
                 users_acl.append({f"{service_accounts.lsdc}": "rw"})
 
             groups_acl.append({"n2sn-right-dataadmin": "rw"})
-            groups_acl.append({f"n2sn-right-dataadmin-{beamline_tla}": "rw"})
+            groups_acl.append({f"{await beamline_service.custom_data_admin_group(beamline_tla)}": "rw"})
 
             directory = {
                 "path": str(


### PR DESCRIPTION
The resolves #34 

I've added a optional filed to the database `custom_data_admin_group` which can be set to override the default behaviour of using `n2sn-right-dataadmin-tla` 