### PR TITLE
Add SynchWeb user permission for proposal directories

### DIFF
--- a/src/nsls2api/models/beamlines.py
+++ b/src/nsls2api/models/beamlines.py
@@ -9,9 +9,10 @@ class Detector(pydantic.BaseModel):
     name: str
     directory_name: str | None = None
 
+
 class DetectorView(pydantic.BaseModel):
     detectors: list[Detector] | None = None
-    
+
     class Settings:
         projection = {
             "detectors": "$detectors",
@@ -23,12 +24,12 @@ class DetectorList(pydantic.BaseModel):
     count: int | None = None
 
 
-
 class BeamlineService(pydantic.BaseModel):
     name: str
-    host: Optional[str]
-    port: Optional[int]
-    uri: Optional[str]
+    used_in_production: Optional[bool] = None
+    host: Optional[str] = None
+    port: Optional[int] = None
+    uri: Optional[str] = None
 
 
 class ServicesOnly(pydantic.BaseModel):
@@ -96,6 +97,13 @@ class LsdcServiceAccountView(pydantic.BaseModel):
 
     class Settings:
         projection = {"username": "$service_accounts.lsdc"}
+
+
+class BeamlineServicesSynchwebView(pydantic.BaseModel):
+    synchweb: BeamlineService
+
+    class Settings:
+        projection = {"synchweb": "$services.name"}
 
 
 class DataRootDirectoryView(pydantic.BaseModel):

--- a/src/nsls2api/services/beamline_service.py
+++ b/src/nsls2api/services/beamline_service.py
@@ -6,6 +6,7 @@ from beanie.odm.operators.find.comparison import In
 from nsls2api.api.models.beamline_model import AssetDirectoryGranularity
 from nsls2api.models.beamlines import (
     Beamline,
+    BeamlineService,
     Detector,
     DetectorView,
     ServicesOnly,
@@ -234,3 +235,13 @@ async def proposal_directory_skeleton(name: str):
     directory_list.append(default_directory)
 
     return directory_list
+
+
+# TODO: Improve this method to determine if the beamline uses synchweb or not by looking at the information in the services field in the database.
+async def uses_synchweb(name: str) -> bool:
+    synchweb_beamlines = {"amx", "fmx", "nyx"}
+
+    if name.lower() in synchweb_beamlines:
+        return True
+    else:
+        return False


### PR DESCRIPTION
Added the missing SynchWeb user read permissions if the beamline uses the SynchWeb service.

The method of determining if a beamline uses SynchWeb is to look at the `services` field in the beamline document which is a list of services that the beamline uses.  If one exists with the `name` of `synchweb` then we assume that the beamline is using SynchWeb

This resolves #40 