### PR TITLE
Update Proposal model with default values

### DIFF
--- a/src/nsls2api/models/proposals.py
+++ b/src/nsls2api/models/proposals.py
@@ -24,13 +24,13 @@ class User(pydantic.BaseModel):
 class Proposal(beanie.Document):
     proposal_id: str
     data_session: str
-    title: Optional[str]
-    type: Optional[str]
+    title: Optional[str] = None
+    type: Optional[str] = None
     pass_type_id: Optional[str]
-    instruments: Optional[list[str]]
-    cycles: Optional[list[str]]
-    users: list[User]
-    safs: Optional[list[SafetyForm]]
+    instruments: Optional[list[str]] = []
+    cycles: Optional[list[str]] = []
+    users: list[User] = []
+    safs: Optional[list[SafetyForm]] = []
     created_on: datetime.datetime = pydantic.Field(
         default_factory=datetime.datetime.now
     )


### PR DESCRIPTION
Seems that if some fields are missing from the upstream data services then we are not populating them with a default value.  

We should fix the data ingestion pipeline, but to make sure we catch it here I'm adding some default values in the pydantic model. 

Resolves #46