### PR TITLE
Make the first and last name optional for a user (to match PASS behaviour)

### DIFF
--- a/src/nsls2api/models/proposals.py
+++ b/src/nsls2api/models/proposals.py
@@ -13,11 +13,11 @@ class SafetyForm(pydantic.BaseModel):
 
 
 class User(pydantic.BaseModel):
-    first_name: str
-    last_name: str
-    email: str
-    bnl_id: Optional[str]
-    username: Optional[str]
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    email: str 
+    bnl_id: Optional[str] = None
+    username: Optional[str] = None
     is_pi: bool = False
 
 
@@ -29,7 +29,7 @@ class Proposal(beanie.Document):
     pass_type_id: Optional[str]
     instruments: Optional[list[str]] = []
     cycles: Optional[list[str]] = []
-    users: list[User] = []
+    users: Optional[list[User]] = []
     safs: Optional[list[SafetyForm]] = []
     created_on: datetime.datetime = pydantic.Field(
         default_factory=datetime.datetime.now

--- a/src/nsls2api/models/proposals.py
+++ b/src/nsls2api/models/proposals.py
@@ -15,7 +15,7 @@ class SafetyForm(pydantic.BaseModel):
 class User(pydantic.BaseModel):
     first_name: Optional[str] = None
     last_name: Optional[str] = None
-    email: str 
+    email: str
     bnl_id: Optional[str] = None
     username: Optional[str] = None
     is_pi: bool = False


### PR DESCRIPTION
This should resolve #43 

There is a proposal with a user with `null` for both names (proposal_id = 300551) which is only in cycle 2016-1