### PR TITLE
Update stats API to include NSLS2 proposals per cycle

### DIFF
--- a/src/nsls2api/api/models/stats_model.py
+++ b/src/nsls2api/api/models/stats_model.py
@@ -1,4 +1,10 @@
+from typing import Optional
 import pydantic
+
+
+class ProposalsPerCycleModel(pydantic.BaseModel):
+    cycle: str
+    proposal_count: int = 0
 
 
 class StatsModel(pydantic.BaseModel):
@@ -7,6 +13,7 @@ class StatsModel(pydantic.BaseModel):
     beamline_count: int
     commissioning_proposal_count: int
     facility_data_health: bool
+    nsls2_proposals_per_cycle: Optional[list[ProposalsPerCycleModel]] = []
 
 
 class AboutModel(pydantic.BaseModel):

--- a/src/nsls2api/api/v1/stats_api.py
+++ b/src/nsls2api/api/v1/stats_api.py
@@ -1,7 +1,13 @@
 import fastapi
+from pydantic_core import ValidationError
 
 from nsls2api._version import version as api_version
-from nsls2api.api.models.stats_model import AboutModel, StatsModel
+from nsls2api.api.models.stats_model import (
+    AboutModel,
+    StatsModel,
+    ProposalsPerCycleModel,
+)
+from nsls2api.infrastructure.logging import logger
 from nsls2api.services import (
     beamline_service,
     facility_service,
@@ -10,21 +16,34 @@ from nsls2api.services import (
 
 router = fastapi.APIRouter()
 
+
 @router.get("/stats", response_model=StatsModel)
 async def stats():
-    proposals = await proposal_service.proposal_count()
+    total_proposals = await proposal_service.proposal_count()
     beamlines = await beamline_service.beamline_count()
     facilities = await facility_service.facilities_count()
     commissioning = len(await proposal_service.commissioning_proposals())
 
-    faciltiy_data_health = await facility_service.is_healthy("nsls2")
+    facility_data_health = await facility_service.is_healthy("nsls2")
+
+    nsls2_proposals_per_cycle: list[ProposalsPerCycleModel] = []
+
+    nsls2_cycle_list = await facility_service.facility_cycles("nsls2")
+    for cycle in nsls2_cycle_list:
+        proposal_list = await proposal_service.fetch_proposals_for_cycle(cycle)
+        if proposal_list is not None:
+            model = ProposalsPerCycleModel(
+                cycle=cycle, proposal_count=len(proposal_list)
+            )
+            nsls2_proposals_per_cycle.append(model)
 
     model = StatsModel(
         facility_count=facilities,
         beamline_count=beamlines,
-        proposal_count=proposals,
+        proposal_count=total_proposals,
         commissioning_proposal_count=commissioning,
-        facility_data_health=faciltiy_data_health,
+        facility_data_health=facility_data_health,
+        nsls2_proposals_per_cycle=nsls2_proposals_per_cycle,
     )
     return model
 


### PR DESCRIPTION
As an added check in ensuring we are syncing correctly, I have added the total proposals per NSLS-II cycle in addtion to just the total number of proposals.  