### PR TITLE
A number of small improvements to PASS synchronization

### DIFF
--- a/src/nsls2api/services/background_service.py
+++ b/src/nsls2api/services/background_service.py
@@ -89,7 +89,7 @@ async def worker_function():
     while True:
         jobs = await pending_jobs()
         if len(jobs) == 0:
-            logger.info("No new jobs to process.")
+            logger.debug("No new jobs to process.")
             await asyncio.sleep(1)
             continue
 

--- a/src/nsls2api/services/background_service.py
+++ b/src/nsls2api/services/background_service.py
@@ -108,7 +108,7 @@ async def worker_function():
                     logger.info(
                         f"Processing job {job.id} to update cycle information for the {job.sync_parameters.facility} facilty (from {job.sync_parameters.sync_source})."
                     )
-                    await proposal_service.worker_update_cycle_information(
+                    await proposal_service.worker_update_proposal_to_cycle_mapping(
                         job.sync_parameters.facility, job.sync_parameters.cycle, job.sync_parameters.sync_source
                     )
                 case JobActions.synchronize_cycles:

--- a/src/nsls2api/services/facility_service.py
+++ b/src/nsls2api/services/facility_service.py
@@ -151,7 +151,7 @@ async def worker_synchronize_cycles_from_pass(
             pass_cycle.User_Facility_ID
         )
 
-        logger.info(f"Processing cycle: {pass_cycle.Name} for {facility.name}.")
+        logger.info(f"Synchronizing cycle: {pass_cycle.Name} for {facility.name}.")
 
         cycle = Cycle(
             name=pass_cycle.Name,


### PR DESCRIPTION
Some small changes bundled together.
* Improved the worker function names to be clearer what they are doing.
* When we sync the cycle list, also populate it with the allocated proposals for that cycle
* and most importantly, now I am sure by background worker process is working, change the chatty info log messages to debug. 