### PR TITLE
Make slack config env vars optional

### DIFF
--- a/src/nsls2api/infrastructure/config.py
+++ b/src/nsls2api/infrastructure/config.py
@@ -53,10 +53,10 @@ class Settings(BaseSettings):
     socks_proxy: str
 
     # Slack settings
-    slack_bot_token: str
-    superadmin_slack_user_token: str
-    slack_signing_secret: str
-    nsls2_workspace_team_id: str
+    slack_bot_token: str | None = None
+    superadmin_slack_user_token: str | None = None
+    slack_signing_secret: str | None = None
+    nsls2_workspace_team_id: str | None = None
 
     model_config = SettingsConfigDict(
         env_file=str(Path(__file__).parent.parent / ".env"), extra='ignore', validate_default=False,

--- a/src/nsls2api/infrastructure/config.py
+++ b/src/nsls2api/infrastructure/config.py
@@ -59,7 +59,7 @@ class Settings(BaseSettings):
     nsls2_workspace_team_id: str | None = None
 
     model_config = SettingsConfigDict(
-        env_file=str(Path(__file__).parent.parent / ".env"), extra='ignore', validate_default=False,
+        env_file=str(Path(__file__).parent.parent / ".env"), extra='ignore',
     )
 
 


### PR DESCRIPTION
Another attempt to make the dev site start up without having to specify the slack config vars