### PR TITLE
Add groupname field to username endpoint response

### DIFF
--- a/src/nsls2api/api/models/proposal_model.py
+++ b/src/nsls2api/api/models/proposal_model.py
@@ -9,11 +9,12 @@ from nsls2api.api.models.beamline_model import AssetDirectoryGranularity
 
 class UsernamesList(pydantic.BaseModel):
     usernames: list[str]
+    groupname: str
     proposal_id: Optional[str]
     count: int
 
     model_config = {
-        "json_schema_extra": {"examples": [{"usernames": ["rdeckard", "rbatty"]}]}
+        "json_schema_extra": {"examples": [{"groupname": "pass-314159", "usernames": ["rdeckard", "rbatty"]}]}
     }
 
 

--- a/src/nsls2api/api/v1/proposal_api.py
+++ b/src/nsls2api/api/v1/proposal_api.py
@@ -190,8 +190,12 @@ async def get_proposal_usernames(proposal_id: int):
     proposal_usernames = await proposal_service.fetch_usernames_from_proposal(
         proposal_id
     )
+
+    proposal_groupname = await proposal_service.generate_data_session_for_proposal(proposal_id)
+
     response_model = UsernamesList(
         usernames=proposal_usernames,
+        groupname=proposal_groupname,
         proposal_id=str(proposal_id),
         count=len(proposal_usernames),
     )

--- a/src/nsls2api/infrastructure/config.py
+++ b/src/nsls2api/infrastructure/config.py
@@ -53,13 +53,18 @@ class Settings(BaseSettings):
     socks_proxy: str
 
     # Slack settings
-    slack_bot_token: str
-    superadmin_slack_user_token: str
-    slack_signing_secret: str
-    nsls2_workspace_team_id: str
+    slack_bot_token: str | None = ""
+    superadmin_slack_user_token: str | None = ""
+    slack_signing_secret: str | None = ""
+    nsls2_workspace_team_id: str | None = ""
+
+    # Universal Proposal System
+    universal_proposal_system_api_url: HttpUrl = "https://ups.servicenowservices.com/api"
+    universal_proposal_system_api_user: str | None = ""
+    universal_proposal_system_api_password : str | None = ""
 
     model_config = SettingsConfigDict(
-        env_file=str(Path(__file__).parent.parent / ".env"), extra='ignore', validate_default=False,
+        env_file=str(Path(__file__).parent.parent / ".env"), extra='ignore',
     )
 
 


### PR DESCRIPTION
In the old API there was an endpoint that gave the group name and the list of usernames.  In the new version the groupname was accidentally omitted.   This is something that the powershell script that populates the groups relies on. 

Also, included a small fix to allow startup even if we are missing variables from our `.env` file.