### PR TITLE
Give nsls2data write for detector directories

### DIFF
--- a/src/nsls2api/services/beamline_service.py
+++ b/src/nsls2api/services/beamline_service.py
@@ -214,7 +214,7 @@ async def proposal_directory_skeleton(name: str):
     if service_usernames.workflow is not None:
         users_acl.append({f"{service_usernames.workflow}": "r"})
     
-    users_acl.append({"nsls2data": "r"})
+    users_acl.append({"nsls2data": "rw"})
 
     groups_acl.append({f"{await custom_data_admin_group(name)}": "r"})
     groups_acl.append({"n2sn-right-dataadmin": "r"})


### PR DESCRIPTION
After reflection with @mrakitin and @danielballan, we've determined that it should be broadly safe to give nsl2data write access to these directories.

The initial motivation for this is that under POSIX ACLs the default ACL for owner that gets inherited by newly created files does not allow them to be writable for softioc.