### PR TITLE
Cleanup endpoint for beamline skeleton

### DIFF
--- a/src/nsls2api/api/models/proposal_model.py
+++ b/src/nsls2api/api/models/proposal_model.py
@@ -14,7 +14,16 @@ class UsernamesList(pydantic.BaseModel):
     count: int
 
     model_config = {
-        "json_schema_extra": {"examples": [{"groupname": "pass-314159", "usernames": ["rdeckard", "rbatty"]}]}
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "groupname": "pass-314159",
+                    "usernames": ["rdeckard", "rbatty"],
+                    "proposal_id": "666666",
+                    "count": 2,
+                }
+            ]
+        }
     }
 
 
@@ -69,7 +78,9 @@ class ProposalDirectories(pydantic.BaseModel):
     cycle: str | None = None
     users: list[dict[str, str]]
     groups: list[dict[str, str]]
-    directory_most_granular_level: AssetDirectoryGranularity | None = AssetDirectoryGranularity.day
+    directory_most_granular_level: AssetDirectoryGranularity | None = (
+        AssetDirectoryGranularity.day
+    )
 
     model_config = {
         "json_schema_extra": {
@@ -93,26 +104,6 @@ class ProposalDirectories(pydantic.BaseModel):
             ]
         }
     }
-
-
-# Not used - may remove
-class ACL(pydantic.BaseModel):
-    entity: str
-    permissions: str
-
-
-# Not used - may remove
-class Directory(pydantic.BaseModel):
-    path: str
-    is_aboslute: bool
-    owner: str
-    group: str
-    acls: list[ACL] | None = []
-
-
-# Not used - may remove
-class ProposalDirectorySkeleton(pydantic.BaseModel):
-    asset_directories: list[Directory]
 
 
 class ProposalDirectoriesList(pydantic.BaseModel):

--- a/src/nsls2api/api/models/proposal_model.py
+++ b/src/nsls2api/api/models/proposal_model.py
@@ -4,7 +4,7 @@ from typing import Optional
 import pydantic
 
 from nsls2api.models.proposals import Proposal, User
-from nsls2api.models.beamlines import AssetDirectoryGranularity
+from nsls2api.models.beamlines import DirectoryGranularity
 
 
 class UsernamesList(pydantic.BaseModel):
@@ -78,8 +78,8 @@ class ProposalDirectories(pydantic.BaseModel):
     cycle: str | None = None
     users: list[dict[str, str]]
     groups: list[dict[str, str]]
-    directory_most_granular_level: AssetDirectoryGranularity | None = (
-        AssetDirectoryGranularity.day
+    directory_most_granular_level: DirectoryGranularity | None = (
+        DirectoryGranularity.day
     )
 
     model_config = {

--- a/src/nsls2api/api/v1/beamline_api.py
+++ b/src/nsls2api/api/v1/beamline_api.py
@@ -10,7 +10,12 @@ from nsls2api.infrastructure.security import (
     get_current_user,
     validate_admin_role,
 )
-from nsls2api.models.beamlines import Beamline, BeamlineService, DetectorList
+from nsls2api.models.beamlines import (
+    Beamline,
+    BeamlineService,
+    DetectorList,
+    AssetDirectoryList,
+)
 from nsls2api.services import beamline_service
 
 router = fastapi.APIRouter()
@@ -35,14 +40,18 @@ async def get_beamline_accounts(name: str, api_key: APIKey = Depends(get_current
         )
     return service_accounts
 
+
 @router.get("/beamline/{name}/slack-channel-managers")
-async def get_beamline_slack_channel_managers(name: str, api_key: APIKey = Depends(get_current_user)):
+async def get_beamline_slack_channel_managers(
+    name: str, api_key: APIKey = Depends(get_current_user)
+):
     slack_channel_managers = await beamline_service.slack_channel_managers(name)
     if slack_channel_managers is None:
         raise HTTPException(
             status_code=404, detail=f"Beamline named {name} could not be found"
         )
     return slack_channel_managers
+
 
 @router.get(
     "/beamline/{name}/detectors", response_model=DetectorList, include_in_schema=True
@@ -62,9 +71,10 @@ async def get_beamline_detectors(name: str) -> DetectorList:
 @router.get(
     "/beamline/{name}/proposal-directory-skeleton",
     response_model=ProposalDirectoriesList,
+    deprecated=True,
 )
 async def get_beamline_proposal_directory_skeleton(name: str):
-    directory_skeleton = await beamline_service.proposal_directory_skeleton(name)
+    directory_skeleton = await beamline_service.assets_directory_skeleton(name)
     if directory_skeleton is None:
         raise HTTPException(
             status_code=404,
@@ -77,14 +87,11 @@ async def get_beamline_proposal_directory_skeleton(name: str):
 
 
 @router.get(
-    "/beamline/{name}/proposal-directory-skeleton-alternate",
-    response_model=ProposalDirectoriesList,
-    include_in_schema=False,
+    "/beamline/{name}/asset-directory-skeleton",
+    response_model=AssetDirectoryList,
 )
-async def get_beamline_proposal_directory_skeleton_alternate(
-    name: str, proposal_id: int
-):
-    directory_skeleton = await beamline_service.proposal_directory_skeleton(name)
+async def get_beamline_asset_directory_skeleton(name: str):
+    directory_skeleton = await beamline_service.assets_directory_skeleton(name)
     if directory_skeleton is None:
         raise HTTPException(
             status_code=404,

--- a/src/nsls2api/api/v1/beamline_api.py
+++ b/src/nsls2api/api/v1/beamline_api.py
@@ -14,7 +14,7 @@ from nsls2api.models.beamlines import (
     Beamline,
     BeamlineService,
     DetectorList,
-    AssetDirectoryList,
+    DirectoryList,
 )
 from nsls2api.services import beamline_service
 
@@ -74,7 +74,7 @@ async def get_beamline_detectors(name: str) -> DetectorList:
     deprecated=True,
 )
 async def get_beamline_proposal_directory_skeleton(name: str):
-    directory_skeleton = await beamline_service.assets_directory_skeleton(name)
+    directory_skeleton = await beamline_service.directory_skeleton(name)
     if directory_skeleton is None:
         raise HTTPException(
             status_code=404,
@@ -87,11 +87,11 @@ async def get_beamline_proposal_directory_skeleton(name: str):
 
 
 @router.get(
-    "/beamline/{name}/asset-directory-skeleton",
-    response_model=AssetDirectoryList,
+    "/beamline/{name}/directory-skeleton",
+    response_model=DirectoryList,
 )
-async def get_beamline_asset_directory_skeleton(name: str):
-    directory_skeleton = await beamline_service.assets_directory_skeleton(name)
+async def get_beamline_directory_skeleton(name: str):
+    directory_skeleton = await beamline_service.directory_skeleton(name)
     if directory_skeleton is None:
         raise HTTPException(
             status_code=404,

--- a/src/nsls2api/cli/auth.py
+++ b/src/nsls2api/cli/auth.py
@@ -11,9 +11,7 @@ from configparser import NoOptionError, NoSectionError
 from nsls2api.infrastructure.security import SpecialUsers
 
 
-BASE_URL = "http://localhost:8080"
-
-__logged_in_username = None
+BASE_URL = "http://localhost:8000"
 
 app = typer.Typer()
 
@@ -36,15 +34,15 @@ def config_from_file() -> Optional[str]:
 
 
 @app.command()
-def login():
+def status():
     # Let's see if there is a token in the local config file ?
     token = config_from_file()
     if token is None:
         print("No API token found")
         token = getpass.getpass(prompt="Please enter your API token:")
         if len(token) == 0:
-            __logged_in_username: SpecialUsers = SpecialUsers.anonymous
-            print("Logged in as anonymous")
+            logged_in_username: SpecialUsers = SpecialUsers.anonymous
+            print("Authenticated as anonymous")
             return
 
     # Let's test this token
@@ -54,21 +52,13 @@ def login():
             headers = {"Authorization": f"{token}"}
             response = client.get(url, headers=headers)
             response.raise_for_status()
-            __logged_in_username = response.json()
+            logged_in_username = response.json()
     except httpx.RequestError as exc:
         print(f"An error occurred while trying to login {exc}")
         raise
 
-    print(f"Logged in as {__logged_in_username}")
+    print(f"Authenticated as {logged_in_username}")
 
 
-@app.command()
-def logout():
-    print("Logging you out...")
 
 
-@app.command()
-def status():
-    print(
-        f"You might be logged in as {__logged_in_username}, or you might not be - {rich.emoji.Emoji('person_shrugging')}"
-    )

--- a/src/nsls2api/models/beamlines.py
+++ b/src/nsls2api/models/beamlines.py
@@ -7,7 +7,7 @@ import pydantic
 from enum import StrEnum
 
 
-class AssetDirectoryGranularity(StrEnum):
+class DirectoryGranularity(StrEnum):
     """
     Represents the granularity options for asset directory YYYY/MM/DD/HH tree structure.
     The value specifies the most granular level to create directories for.  If no date
@@ -21,15 +21,15 @@ class AssetDirectoryGranularity(StrEnum):
     hour = "hour"
 
 
-class AssetDirectory(pydantic.BaseModel):
+class Directory(pydantic.BaseModel):
     path: str
     owner: str
     group: str | None = None
     beamline: str | None = None
     users: list[dict[str, str]]
     groups: list[dict[str, str]]
-    directory_most_granular_level: AssetDirectoryGranularity | None = (
-        AssetDirectoryGranularity.day
+    directory_most_granular_level: DirectoryGranularity | None = (
+        DirectoryGranularity.day
     )
 
     model_config = {
@@ -60,15 +60,15 @@ class AssetDirectory(pydantic.BaseModel):
     }
 
 
-class AssetDirectoryList(pydantic.BaseModel):
+class DirectoryList(pydantic.BaseModel):
     directory_count: int
-    directories: list[AssetDirectory]
+    directories: list[Directory]
 
 
 class Detector(pydantic.BaseModel):
     name: str
     directory_name: str
-    granularity: AssetDirectoryGranularity | None = AssetDirectoryGranularity.day
+    granularity: DirectoryGranularity | None = DirectoryGranularity.day
     description: str | None = None
     manufacturer: str | None = None
 

--- a/src/nsls2api/models/beamlines.py
+++ b/src/nsls2api/models/beamlines.py
@@ -21,6 +21,50 @@ class AssetDirectoryGranularity(StrEnum):
     hour = "hour"
 
 
+class AssetDirectory(pydantic.BaseModel):
+    path: str
+    owner: str
+    group: str | None = None
+    beamline: str | None = None
+    users: list[dict[str, str]]
+    groups: list[dict[str, str]]
+    directory_most_granular_level: AssetDirectoryGranularity | None = (
+        AssetDirectoryGranularity.day
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "directory_count": 1,
+                    "directories": [
+                        {
+                            "path": "assets/detector1",
+                            "owner": "nsls2data",
+                            "group": "nsls2data",
+                            "beamline": "TST",
+                            "directory_most_granular_level": "month",
+                            "users": [
+                                {"softioc-tst": "rw"},
+                                {"service-account": "rw"},
+                            ],
+                            "groups": [
+                                {"dataadmins": "rw"},
+                                {"datareaders": "r"},
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+
+
+class AssetDirectoryList(pydantic.BaseModel):
+    directory_count: int
+    directories: list[AssetDirectory]
+
+
 class Detector(pydantic.BaseModel):
     name: str
     directory_name: str

--- a/src/nsls2api/services/beamline_service.py
+++ b/src/nsls2api/services/beamline_service.py
@@ -223,7 +223,7 @@ async def update_data_admins(beamline_name: str, data_admins: list[str]):
     )
 
 
-async def proposal_directory_skeleton(name: str):
+async def assets_directory_skeleton(name: str):
     detector_list = await detectors(name.upper())
 
     directory_list = []

--- a/src/nsls2api/services/beamline_service.py
+++ b/src/nsls2api/services/beamline_service.py
@@ -6,7 +6,7 @@ from beanie.odm.operators.find.comparison import In
 from beanie.odm.operators.find.array import ElemMatch
 from beanie.odm.operators.update.general import Set
 
-from nsls2api.models.beamlines import AssetDirectoryGranularity
+from nsls2api.models.beamlines import DirectoryGranularity
 from nsls2api.infrastructure.logging import logger
 from nsls2api.models.beamlines import (
     Beamline,
@@ -223,7 +223,7 @@ async def update_data_admins(beamline_name: str, data_admins: list[str]):
     )
 
 
-async def assets_directory_skeleton(name: str):
+async def directory_skeleton(name: str):
     detector_list = await detectors(name.upper())
 
     directory_list = []
@@ -261,7 +261,7 @@ async def assets_directory_skeleton(name: str):
         "users": users_acl,
         "groups": groups_acl,
         "beamline": name.upper(),
-        "directory_most_granular_level": AssetDirectoryGranularity.flat,
+        "directory_most_granular_level": DirectoryGranularity.flat,
     }
     directory_list.append(asset_directory)
 
@@ -287,7 +287,7 @@ async def assets_directory_skeleton(name: str):
         "users": users_acl,
         "groups": groups_acl,
         "beamline": name.upper(),
-        "directory_most_granular_level": AssetDirectoryGranularity.day,
+        "directory_most_granular_level": DirectoryGranularity.day,
     }
     directory_list.append(default_directory)
 


### PR DESCRIPTION
For some unknown reason, the name I gave the endpoint to generate the directory skeleton layout for a given beamline is called `proposal-directory-skeleton` which does not make sense.  I've added a new endpoint `directory-skeleton` and deprecated the `proposal-directory-skeleton` endpoint with a view to removing in the future. 

Also separated out the response model for the proposal directories from the beamline directory skeleton.


