### PR TITLE
🚮 Clean up old variables in the docs

### DIFF
--- a/src/nsls2api/api/v1/admin_api.py
+++ b/src/nsls2api/api/v1/admin_api.py
@@ -57,7 +57,9 @@ async def generate_user_apikey(username: str):
 async def generate_fake_proposal(
     add_specific_user: str | None = None,
 ) -> Optional[SingleProposal]:
-    proposal = await proposal_service.generate_fake_test_proposal()
+    proposal = await proposal_service.generate_fake_test_proposal(
+        None, add_specific_user
+    )
 
     if proposal is None:
         raise HTTPException(

--- a/src/nsls2api/api/v1/admin_api.py
+++ b/src/nsls2api/api/v1/admin_api.py
@@ -55,7 +55,7 @@ async def generate_user_apikey(username: str):
 
 @router.post("/admin/proposal/generate-test")
 async def generate_fake_proposal(
-    add_specific_user: str,
+    add_specific_user: str | None = None,
 ) -> Optional[SingleProposal]:
     proposal = await proposal_service.generate_fake_test_proposal()
 

--- a/src/nsls2api/api/v1/admin_api.py
+++ b/src/nsls2api/api/v1/admin_api.py
@@ -55,14 +55,8 @@ async def generate_user_apikey(username: str):
 
 @router.post("/admin/proposal/generate-test")
 async def generate_fake_proposal(
-    use_real_people: bool = False,
+    add_specific_user: str,
 ) -> Optional[SingleProposal]:
-    if use_real_people:
-        raise HTTPException(
-            status_code=fastapi.status.HTTP_501_NOT_IMPLEMENTED,
-            detail="Creating proposals using real people is not implemented yet",
-        )
-
     proposal = await proposal_service.generate_fake_test_proposal()
 
     if proposal is None:


### PR DESCRIPTION
`use_real_people` boolean was still appearing in the docs when it has since been replaced with `add_specific_user`
This corrects that.