### PR TITLE
Add TST beamline to endpoint tests

### DIFF
--- a/integration-tests/check_all_beamlines.http
+++ b/integration-tests/check_all_beamlines.http
@@ -320,6 +320,17 @@ Accept: application/json
     });
 %}
 
+### Check TST Details
+# @name tst-details
+GET http://{{host}}/v1/beamline/tst
+Accept: application/json
+
+> {%
+    client.test("Request executed successfully", function () {
+        client.assert(response.status === 200, "Response status is not 200");
+    });
+%}
+
 ### Check XFM Details
 # @name xfm-details
 GET http://{{host}}/v1/beamline/xfm


### PR DESCRIPTION
The `TST` beamline was missing from the list of simple endpoint checks.