### PR TITLE
Updates to add_detector endpoint

### DIFF
--- a/src/nsls2api/api/v1/beamline_api.py
+++ b/src/nsls2api/api/v1/beamline_api.py
@@ -99,7 +99,7 @@ async def add_detector(name: str, detector: Detector):
 
 
 @router.delete(
-    "/beamline/{name}/detector/",
+    "/beamline/{name}/delete-detector/",
     include_in_schema=True,
     response_model=Detector,
     dependencies=[Depends(validate_admin_role)],

--- a/src/nsls2api/api/v1/beamline_api.py
+++ b/src/nsls2api/api/v1/beamline_api.py
@@ -112,7 +112,7 @@ async def add_or_delete_detector(
         if new_detector is None:
             raise HTTPException(
                 status_code=409,
-                detail=f"Detector {detector.name} already exists in beamline {name}",
+                detail=f"Detector already exists in beamline {name} with either name '{detector.name}' or directory name '[detector.directory_name}'",
             )
 
         changed_detector = new_detector

--- a/src/nsls2api/api/v1/beamline_api.py
+++ b/src/nsls2api/api/v1/beamline_api.py
@@ -98,6 +98,33 @@ async def add_detector(name: str, detector: Detector):
     return new_detector
 
 
+@router.delete(
+    "/beamline/{name}/detector/",
+    include_in_schema=True,
+    response_model=Detector,
+    dependencies=[Depends(validate_admin_role)],
+)
+async def del_detector(name: str, detector: Detector):
+    logger.info(f"Deleting detector {detector.name} from beamline {name}")
+
+    deleted_detector = await beamline_service.del_detector(
+        beamline_name=name,
+        detector_name=detector.name,
+        directory_name=detector.directory_name,
+        granularity=detector.granularity,
+        description=detector.description,
+        manufacturer=detector.manufacturer,
+    )
+
+    if deleted_detector is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Detector {detector_name} with directory {directory_name} was not found for beamline {beamline_name}",
+        )
+
+    return deleted_detector
+
+
 @router.get(
     "/beamline/{name}/proposal-directory-skeleton",
     response_model=ProposalDirectoriesList,

--- a/src/nsls2api/api/v1/beamline_api.py
+++ b/src/nsls2api/api/v1/beamline_api.py
@@ -98,7 +98,7 @@ async def add_detector(name: str, detector: Detector):
     return new_detector
 
 
-@router.delete(
+@router.put(
     "/beamline/{name}/delete-detector/",
     include_in_schema=True,
     response_model=Detector,

--- a/src/nsls2api/api/v1/beamline_api.py
+++ b/src/nsls2api/api/v1/beamline_api.py
@@ -110,16 +110,12 @@ async def delete_detector(name: str, detector: Detector):
     deleted_detector = await beamline_service.delete_detector(
         beamline_name=name,
         detector_name=detector.name,
-        directory_name=detector.directory_name,
-        granularity=detector.granularity,
-        description=detector.description,
-        manufacturer=detector.manufacturer,
     )
 
     if deleted_detector is None:
         raise HTTPException(
             status_code=404,
-            detail=f"Detector {detector_name} with directory {directory_name} was not found for beamline {beamline_name}",
+            detail=f"Detector {detector_name} was not found for beamline {beamline_name}",
         )
 
     return deleted_detector

--- a/src/nsls2api/api/v1/beamline_api.py
+++ b/src/nsls2api/api/v1/beamline_api.py
@@ -104,10 +104,10 @@ async def add_detector(name: str, detector: Detector):
     response_model=Detector,
     dependencies=[Depends(validate_admin_role)],
 )
-async def del_detector(name: str, detector: Detector):
+async def delete_detector(name: str, detector: Detector):
     logger.info(f"Deleting detector {detector.name} from beamline {name}")
 
-    deleted_detector = await beamline_service.del_detector(
+    deleted_detector = await beamline_service.delete_detector(
         beamline_name=name,
         detector_name=detector.name,
         directory_name=detector.directory_name,

--- a/src/nsls2api/api/v1/beamline_api.py
+++ b/src/nsls2api/api/v1/beamline_api.py
@@ -70,6 +70,7 @@ async def get_beamline_detectors(name: str) -> DetectorList:
     response_model = DetectorList(detectors=detectors, count=len(detectors))
     return response_model
 
+
 @router.put(
     "/beamline/{name}/detector/",
     include_in_schema=True,
@@ -83,15 +84,19 @@ async def add_detector(name: str, detector: Detector):
         beamline_name=name,
         detector_name=detector.name,
         directory_name=detector.directory_name,
+        granularity=detector.granularity,
+        description=detector.description,
+        manufacturer=detector.manufacturer,
     )
 
     if new_detector is None:
         raise HTTPException(
             status_code=409,
             detail=f"Detector {detector.name} already exists in beamline {name}",
-    )
+        )
 
     return new_detector
+
 
 @router.get(
     "/beamline/{name}/proposal-directory-skeleton",

--- a/src/nsls2api/services/beamline_service.py
+++ b/src/nsls2api/services/beamline_service.py
@@ -139,10 +139,6 @@ async def add_detector(
 async def delete_detector(
     beamline_name: str,
     detector_name: str,
-    directory_name: str,
-    granularity: DirectoryGranularity,
-    description: str,
-    manufacturer: str,
 ) -> Optional[Detector]:
     """
     Delete a detector from a beamline.
@@ -150,36 +146,25 @@ async def delete_detector(
     Args:
         beamline_name (str): The name of the beamline.
         detector_name (str): The name of the detector.
-        directory_name (str): The directory name of the detector.
-        granularity (DirectoryGranularity): The time-granularity of directories to generate.
-        description (str): The description of the detector.
-        manufacturer (str): The manufacturer of the detector.
 
     Returns:
         Optional[Detector]: The deleted Detector object if successful, None otherwise.
     """
     beamline = await Beamline.find_one(Beamline.name == beamline_name.upper())
 
-    old_detector = Detector(
-        name=detector_name,
-        directory_name=directory_name,
-        granularity=granularity,
-        description=description,
-        manufacturer=manufacturer,
-    )
+    old_detector_name = detector_name
 
     deleted_detector = next(
         (
             detector
             for detector in beamline.detectors
-            if detector.name == old_detector.name
-            and detector.directory_name == old_detector.directory_name
+            if detector.name == old_detector_name
         ),
         None,
     )
     if deleted_detector is None:
         logger.info(
-            f"Detector with name {detector_name} and directory name {directory_name} was not found for beamline {beamline_name}"
+            f"Detector {old_detector_name} was not found for beamline {beamline_name}"
         )
         return None
 
@@ -187,7 +172,7 @@ async def delete_detector(
     beamline.last_updated = datetime.datetime.now()
     await beamline.save()
     logger.info(
-        f"Detector with directory name {directory_name} was deleted from beamline {beamline_name}"
+        f"Detector {deleted_detector.name} was deleted from beamline {beamline_name}"
     )
 
     return deleted_detector

--- a/src/nsls2api/services/beamline_service.py
+++ b/src/nsls2api/services/beamline_service.py
@@ -120,9 +120,7 @@ async def add_detector(
         manufacturer=manufacturer,
     )
 
-    current_detector_names = (
-        detector.name for detector in beamlines.detectors
-    )
+    current_detector_names = (detector.name for detector in beamlines.detectors)
     current_directory_names = (
         detector.directory_name for detector in beamline.detectors
     )
@@ -130,7 +128,7 @@ async def add_detector(
         logger.info(
             f"Detector with name {detector_name} already exists in beamline {beamline_name}"
         )
-        return None:
+        return None
     elif directory_name in current_directory_names:
         logger.info(
             f"Detector with directory name {directory_name} already exists in beamline {beamline_name}"

--- a/src/nsls2api/services/beamline_service.py
+++ b/src/nsls2api/services/beamline_service.py
@@ -89,9 +89,12 @@ async def detectors(name: str) -> Optional[list[Detector]]:
 
 
 async def add_detector(
-        beamline_name: str,
-        detector_name: str,
-        directory_name: str
+    beamline_name: str,
+    detector_name: str,
+    directory_name: str,
+    granularity: DirectoryGranularity,
+    description: str,
+    manufacturer: str,
 ) -> Optional[Detector]:
     """
     Add a new detector to a beamline.
@@ -100,17 +103,30 @@ async def add_detector(
         beamline_name (str): The name of the beamline.
         detector_name (str): The name of the detector.
         directory_name (str): The directory name of the detector.
+        granularity (DirectoryGranularity): The time-granularity of directories to generate.
+        description (str): The description of the detector.
+        manufacturer (str): The manufacturer of the detector.
 
     Returns:
         Optional[Detector]: The newly created Detector object if successful, None otherwise.
     """
     beamline = await Beamline.find_one(Beamline.name == beamline_name.upper())
 
-    new_detector = Detector(name=detector_name, directory_name=directory_name)
+    new_detector = Detector(
+        name=detector_name,
+        directory_name=directory_name,
+        granularity=granularity,
+        description=description,
+        manufacturer=manufacturer,
+    )
 
-    current_directory_names = (detector.directory_name for detector in beamline.detectors)
+    current_directory_names = (
+        detector.directory_name for detector in beamline.detectors
+    )
     if directory_name in current_directory_names:
-        logger.info(f"Detector with directory name {directory_name} already exists in beamline {beamline_name}")
+        logger.info(
+            f"Detector with directory name {directory_name} already exists in beamline {beamline_name}"
+        )
         return None
     else:
         beamline.detectors.append(new_detector)
@@ -121,12 +137,12 @@ async def add_detector(
 
 
 async def add_service(
-        beamline_name: str,
-        service_name: str,
-        used_in_production: bool = False,
-        host: str = None,
-        port: int = None,
-        uri: str = None,
+    beamline_name: str,
+    service_name: str,
+    used_in_production: bool = False,
+    host: str = None,
+    port: int = None,
+    uri: str = None,
 ) -> Optional[BeamlineService]:
     """
     Add a new service to a beamline.

--- a/src/nsls2api/services/beamline_service.py
+++ b/src/nsls2api/services/beamline_service.py
@@ -120,10 +120,18 @@ async def add_detector(
         manufacturer=manufacturer,
     )
 
+    current_detector_names = (
+        detector.name for detector in beamlines.detectors
+    )
     current_directory_names = (
         detector.directory_name for detector in beamline.detectors
     )
-    if directory_name in current_directory_names:
+    if detector_name in current_detector_names:
+        logger.info(
+            f"Detector with name {detector_name} already exists in beamline {beamline_name}"
+        )
+        return None:
+    elif directory_name in current_directory_names:
         logger.info(
             f"Detector with directory name {directory_name} already exists in beamline {beamline_name}"
         )

--- a/src/nsls2api/services/beamline_service.py
+++ b/src/nsls2api/services/beamline_service.py
@@ -136,51 +136,6 @@ async def add_detector(
     return new_detector
 
 
-async def add_service(
-    beamline_name: str,
-    service_name: str,
-    used_in_production: bool = False,
-    host: str = None,
-    port: int = None,
-    uri: str = None,
-) -> Optional[BeamlineService]:
-    """
-    Add a new service to a beamline.
-
-    Args:
-        beamline_name (str): The name of the beamline.
-        service_name (str): The name of the service.
-        used_in_production (bool, optional): Whether the service is used in production. Defaults to False.
-        host (str, optional): The host of the service. Defaults to None.
-        port (int, optional): The port of the service. Defaults to None.
-        uri (str, optional): The URI of the service. Defaults to None.
-
-    Returns:
-        Optional[BeamlineService]: The newly created BeamlineService object if successful, None otherwise.
-    """
-    beamline = await Beamline.find_one(Beamline.name == beamline_name.upper())
-
-    service = BeamlineService(
-        name=service_name,
-        used_in_production=used_in_production,
-        host=host,
-        port=port,
-        uri=uri,
-    )
-
-    if await check_service_exists(beamline_name, service_name):
-        logger.info(
-            f"Service {service_name} already exists in beamline {beamline_name}"
-        )
-        return None
-    else:
-        beamline.services.append(service)
-        beamline.last_updated = datetime.datetime.now()
-        await beamline.save()
-
-    return service
-
-
 async def service_accounts(name: str) -> Optional[ServiceAccounts]:
     accounts = await Beamline.find_one(Beamline.name == name.upper()).project(
         ServiceAccountsView

--- a/src/nsls2api/services/beamline_service.py
+++ b/src/nsls2api/services/beamline_service.py
@@ -136,7 +136,7 @@ async def add_detector(
     return new_detector
 
 
-async def del_detector(
+async def delete_detector(
     beamline_name: str,
     detector_name: str,
     directory_name: str,


### PR DESCRIPTION
This PR:
* Adds the ability to set all detector/instrument fields from the API
* Adds the ability to delete detectors/instruments via the API
* Removes a redundant copy of `add_service` which crept in
