### PR TITLE
bnlpeople query failures fail more gracefully

### DIFF
--- a/src/nsls2api/services/bnlpeople_service.py
+++ b/src/nsls2api/services/bnlpeople_service.py
@@ -35,7 +35,11 @@ async def get_username_by_id(lifenumber: str) -> Optional[str]:
 
     url = f"{base_url}/api/BNLPeople?employeeNumber={lifenumber}"
     logger.debug(f"Calling URL: {url}")
-    person = await _call_bnlpeople_webservice(url)
+    try:
+        person = await _call_bnlpeople_webservice(url)
+    except Exception as error:
+        logger.exception(error)
+        return None
     logger.debug(person)
     if len(person) == 0 or len(person) > 1:
         logger.warning(

--- a/src/nsls2api/services/bnlpeople_service.py
+++ b/src/nsls2api/services/bnlpeople_service.py
@@ -38,7 +38,8 @@ async def get_username_by_id(lifenumber: str) -> Optional[str]:
     try:
         person = await _call_bnlpeople_webservice(url)
     except Exception as error:
-        logger.exception(error)
+        message = f"BNL People API query failed for lifenumber {lifenumber}"
+        logger.exception(message)
         return None
     logger.debug(person)
     if len(person) == 0 or len(person) > 1:


### PR DESCRIPTION
 * logging to ensure exceptions go into logs
 * return None to prevent failure of entire sync processes - though this leaves the person referenced out of the proposal being synchronized