### PR TITLE
Make top-level and skeleton directory ACLs better match

### DIFF
--- a/src/nsls2api/services/beamline_service.py
+++ b/src/nsls2api/services/beamline_service.py
@@ -337,21 +337,15 @@ async def directory_skeleton(name: str):
 
     service_usernames = await service_accounts(name)
 
-    if service_usernames.ioc is not None:
-        users_acl.append({f"{service_usernames.ioc}": "r"})
-
-    users_acl.append({"softioc": "r"})
+    users_acl.append({"nsls2data": "rw"})
+    users_acl.append({f"{service_usernames.workflow}": "r"})
+    users_acl.append({f"{service_usernames.ioc}": "r"})
 
     if service_usernames.bluesky is not None:
         users_acl.append({f"{service_usernames.bluesky}": "rw"})
 
-    if service_usernames.workflow is not None:
-        users_acl.append({f"{service_usernames.workflow}": "r"})
-
-    users_acl.append({"nsls2data": "rw"})
-
-    groups_acl.append({f"{await data_admin_group(name)}": "r"})
     groups_acl.append({"n2sn-right-dataadmin": "r"})
+    groups_acl.append({f"{await data_admin_group(name)}": "r"})
 
     # Add the asset directory so this has the same permissions as the detector directories
     # and not just inherit from the parent (i.e. proposal) directory.
@@ -368,18 +362,12 @@ async def directory_skeleton(name: str):
 
     users_acl: list[dict[str, str]] = []
 
-    if service_usernames.ioc is not None:
-        users_acl.append({f"{service_usernames.ioc}": "rw"})
-
-    users_acl.append({"softioc": "rw"})
+    users_acl.append({"nsls2data": "rw"})
+    users_acl.append({f"{service_usernames.workflow}": "r"})
+    users_acl.append({f"{service_usernames.ioc}": "rw"})
 
     if service_usernames.bluesky is not None:
         users_acl.append({f"{service_usernames.bluesky}": "rw"})
-
-    if service_usernames.workflow is not None:
-        users_acl.append({f"{service_usernames.workflow}": "r"})
-
-    users_acl.append({"nsls2data": "rw"})
 
     # Add the detector subdirectories
     if detector_list:

--- a/src/nsls2api/services/proposal_service.py
+++ b/src/nsls2api/services/proposal_service.py
@@ -377,16 +377,16 @@ async def directories(proposal_id: str):
             users_acl.append({f"{service_accounts.workflow}": "rw"})
             users_acl.append({f"{service_accounts.ioc}": "rw"})
 
+            if service_accounts.bluesky is not None:
+                users_acl.append({f"{service_accounts.bluesky}": "r"})
             # If beamline uses SynchWeb then add access for synchweb user
             if beamline_service.uses_synchweb(beamline_tla):
                 users_acl.append({"synchweb": "r"})
-
-            groups_acl.append({str(proposal.data_session): "rw"})
-
             # Add LSDC beamline users for the appropriate beamlines (i.e. if the account is defined)
             if service_accounts.lsdc:
                 users_acl.append({f"{service_accounts.lsdc}": "rw"})
 
+            groups_acl.append({str(proposal.data_session): "rw"})
             groups_acl.append({"n2sn-right-dataadmin": "rw"})
             groups_acl.append(
                 {f"{await beamline_service.data_admin_group(beamline_tla)}": "rw"}


### PR DESCRIPTION
This PR makes the ACLs for the top-level of the proposal, and for the skeleton directories, match more closely to eachother so that it is easier to compare and understand how they relate. It also fixes a couple of bugs.

* Remove plain-old `softioc` access for skeleton directories - this account should be unused, and has no access into the proposal directory at all anyway (so this ACL was itself unused)
* If a bluesky service account exists for a beamline, give it read-access to the proposal. Previously access was only given to the skeleton directories, so this account would not have been able to see into the proposal. (These accounts are not used yet)
* Make the `softioc-tla` and `workflow-tla` accounts required for the skeleton directories, since they are already required for the proposal directory, and also because these are accounts which we should have for each "beamline" from the jump.