### PR TITLE
Add prometheus endpoint

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,9 +23,9 @@ asttokens==3.0.0
     # via stack-data
 asyncer==0.0.8
     # via -r requirements-dev.in
-attrs==24.3.0
+attrs==25.1.0
     # via aiohttp
-black==24.10.0
+black==25.1.0
     # via -r requirements-dev.in
 blinker==1.9.0
     # via flask
@@ -33,7 +33,7 @@ brotli==1.1.0
     # via geventhttpclient
 bunnet==1.3.0
     # via -r requirements-dev.in
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   geventhttpclient
     #   httpcore
@@ -59,9 +59,9 @@ distlib==0.3.9
     # via virtualenv
 dnspython==2.7.0
     # via pymongo
-executing==2.1.0
+executing==2.2.0
     # via stack-data
-filelock==3.16.1
+filelock==3.17.0
     # via virtualenv
 flask==3.1.0
     # via
@@ -111,7 +111,7 @@ idna==3.10
     #   yarl
 iniconfig==2.0.0
     # via pytest
-ipython==8.31.0
+ipython==8.32.0
     # via -r requirements-dev.in
 itsdangerous==2.2.0
     # via flask
@@ -134,7 +134,7 @@ lazy-model==0.2.0
     # via bunnet
 linkify-it-py==2.0.3
     # via markdown-it-py
-locust==2.32.5
+locust==2.32.8
     # via -r requirements-dev.in
 markdown-it-py==3.0.0
     # via
@@ -151,7 +151,7 @@ mdit-py-plugins==0.4.2
     # via markdown-it-py
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.5.0
+more-itertools==10.6.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -195,7 +195,7 @@ pluggy==1.5.0
     # via
     #   hatchling
     #   pytest
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via ipython
 propcache==0.2.1
     # via
@@ -207,7 +207,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pydantic==2.10.5
+pydantic==2.10.6
     # via
     #   bunnet
     #   lazy-model
@@ -217,17 +217,17 @@ pygments==2.19.1
     # via
     #   ipython
     #   rich
-pymongo==4.10.1
+pymongo==4.11
     # via bunnet
-pyright==1.1.391
+pyright==1.1.393
     # via -r requirements-dev.in
 pytest==8.3.4
     # via
     #   -r requirements-dev.in
     #   pytest-asyncio
-pytest-asyncio==0.25.2
+pytest-asyncio==0.25.3
     # via -r requirements-dev.in
-pyzmq==26.2.0
+pyzmq==26.2.1
     # via locust
 requests==2.32.3
     # via locust
@@ -236,7 +236,7 @@ rich==13.9.4
     #   hatch
     #   textual
     #   textual-serve
-ruff==0.9.0
+ruff==0.9.4
     # via -r requirements-dev.in
 setuptools==75.8.0
     # via
@@ -264,7 +264,7 @@ textual-serve==1.1.1
     # via textual-dev
 toml==0.10.2
     # via bunnet
-tomli-w==1.1.0
+tomli-w==1.2.0
     # via hatch
 tomlkit==0.13.2
     # via hatch
@@ -272,7 +272,7 @@ traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-trove-classifiers==2025.1.7.14
+trove-classifiers==2025.1.15.22
     # via hatchling
 typing-extensions==4.12.2
     # via
@@ -290,11 +290,11 @@ urllib3==2.3.0
     #   requests
 userpath==1.9.2
     # via hatch
-uv==0.5.16
+uv==0.5.27
     # via
     #   -r requirements-dev.in
     #   hatch
-virtualenv==20.28.1
+virtualenv==20.29.1
     # via hatch
 wcwidth==0.2.13
     # via prompt-toolkit

--- a/requirements.in
+++ b/requirements.in
@@ -11,6 +11,7 @@ jinja2
 jinja-partials
 n2snusertools
 passlib
+prometheus-fastapi-instrumentator
 pydantic
 pydantic-settings
 python-multipart

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ async-timeout==5.0.1
     # via httpx-socks
 beanie==1.29.0
     # via -r requirements.in
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   httpcore
     #   httpx
@@ -33,9 +33,9 @@ decorator==5.1.1
     # via gssapi
 dnspython==2.7.0
     # via pymongo
-faker==33.3.0
+faker==35.2.0
     # via -r requirements.in
-fastapi==0.115.6
+fastapi==0.115.8
     # via -r requirements.in
 gssapi==1.9.0
     # via n2snusertools
@@ -84,7 +84,7 @@ mdit-py-plugins==0.4.2
     # via markdown-it-py
 mdurl==0.1.2
     # via markdown-it-py
-motor==3.6.0
+motor==3.7.0
     # via beanie
 n2snusertools==0.3.7
     # via -r requirements.in
@@ -96,13 +96,17 @@ passlib==1.7.4
     # via -r requirements.in
 platformdirs==4.3.6
     # via textual
-prettytable==3.12.0
+prettytable==3.14.0
     # via n2snusertools
+prometheus-client==0.21.1
+    # via prometheus-fastapi-instrumentator
+prometheus-fastapi-instrumentator==7.0.2
+    # via -r requirements.in
 pyasn1==0.6.1
     # via ldap3
 pycparser==2.22
     # via cffi
-pydantic==2.10.5
+pydantic==2.10.6
     # via
     #   -r requirements.in
     #   beanie
@@ -115,7 +119,7 @@ pydantic-settings==2.7.1
     # via -r requirements.in
 pygments==2.19.1
     # via rich
-pymongo==4.9.2
+pymongo==4.11
     # via motor
 python-dateutil==2.9.0.post0
     # via faker
@@ -123,7 +127,7 @@ python-dotenv==1.0.1
     # via pydantic-settings
 python-multipart==0.0.20
     # via -r requirements.in
-python-socks==2.6.1
+python-socks==2.7.1
     # via httpx-socks
 pyyaml==6.0.2
     # via n2snusertools
@@ -144,10 +148,11 @@ slack-sdk==3.34.0
     #   slack-bolt
 sniffio==1.3.1
     # via anyio
-starlette==0.41.3
+starlette==0.45.3
     # via
     #   asgi-correlation-id
     #   fastapi
+    #   prometheus-fastapi-instrumentator
 textual==1.0.0
     # via -r requirements.in
 toml==0.10.2

--- a/src/nsls2api/api/v1/jobs_api.py
+++ b/src/nsls2api/api/v1/jobs_api.py
@@ -54,7 +54,7 @@ async def sync_dataadmins(request: Request) -> BackgroundJob:
     dependencies=[Depends(get_current_user)],
     include_in_schema=SYNC_ROUTES_IN_SCHEMA,
     tags=["sync"],
-    deprecated=True
+    deprecated=True,
 )
 async def sync_proposal(
     request: Request, proposal_id: str, facility: FacilityName = FacilityName.nsls2
@@ -82,6 +82,7 @@ async def sync_facility_proposal(
         sync_parameters=sync_params,
     )
     return job
+
 
 @router.get(
     "/sync/proposal/types/{facility}",

--- a/src/nsls2api/api/v1/user_api.py
+++ b/src/nsls2api/api/v1/user_api.py
@@ -2,11 +2,11 @@ from typing import Annotated
 
 import fastapi
 from fastapi import Depends
+
+from nsls2api.api.models.person_model import DataSessionAccess, Person
 from nsls2api.infrastructure.security import (
     get_current_user,
 )
-
-from nsls2api.api.models.person_model import Person, DataSessionAccess
 from nsls2api.services import (
     bnlpeople_service,
     person_service,
@@ -87,6 +87,7 @@ async def get_myself(current_user: Annotated[Person, Depends(get_current_user)])
     include_in_schema=True,
     description="Deprecated endpoint included for Tiled compatibility.",
     deprecated=True,
+    operation_id="get_data_session_by_username_v1_deprecated_endpoint",
 )
 async def get_data_sessions_by_username(username: str):
     data_access = await person_service.data_sessions_by_username(username)

--- a/src/nsls2api/infrastructure/app_setup.py
+++ b/src/nsls2api/infrastructure/app_setup.py
@@ -1,6 +1,8 @@
 import asyncio
 from contextlib import asynccontextmanager
 
+from fastapi import FastAPI
+
 from nsls2api.infrastructure import mongodb_setup
 from nsls2api.infrastructure.config import get_settings
 from nsls2api.services import background_service
@@ -12,7 +14,7 @@ local_development_mode = False
 
 
 @asynccontextmanager
-async def app_lifespan(_):
+async def app_lifespan(app: FastAPI):
     # Initialize the MongoDB connection
     await mongodb_setup.init_connection(settings.mongodb_dsn)
 

--- a/src/nsls2api/main.py
+++ b/src/nsls2api/main.py
@@ -6,6 +6,7 @@ import fastapi
 import uvicorn
 from asgi_correlation_id import CorrelationIdMiddleware
 from fastapi.middleware.cors import CORSMiddleware
+from prometheus_fastapi_instrumentator import Instrumentator
 from starlette.middleware import Middleware
 from starlette.staticfiles import StaticFiles
 
@@ -43,6 +44,8 @@ static_root_absolute = current_file_dir_absolute / "static"
 local_development_mode = False
 app_setup.local_development_mode = local_development_mode
 
+# Instantiate the instrumentator
+instrumentator = Instrumentator()
 
 middleware = [Middleware(ProcessTimeMiddleware)]
 
@@ -50,6 +53,11 @@ app = fastapi.FastAPI(
     title="NSLS-II API", middleware=middleware, lifespan=app_setup.app_lifespan
 )
 
+# Instrument the app and expose the /metrics endpoint
+# (this is equivalent to calling instrumentator.instrument(app)
+# and instrumentator.expose(app) in the startup event)
+instrumentator.instrument(app)
+instrumentator.expose(app, endpoint="/metrics", include_in_schema=False)
 
 app.add_middleware(CorrelationIdMiddleware)
 


### PR DESCRIPTION
This is a basic out-of-the-box configuration using the `prometheus-fastapi-instrumentor` package.  

To test, startup the API and go to the `/metrics` endpoint (e.g. `http://127.0.0.1:8000/metrics`)

