### PR TITLE
Add LBMS commissioning proposal support

### DIFF
--- a/src/nsls2api/api/models/proposal_model.py
+++ b/src/nsls2api/api/models/proposal_model.py
@@ -3,8 +3,9 @@ from typing import Optional
 
 import pydantic
 
-from nsls2api.models.proposals import Proposal, User
+from nsls2api.api.models.facility_model import FacilityName
 from nsls2api.models.beamlines import DirectoryGranularity
+from nsls2api.models.proposals import Proposal, User
 
 
 class UsernamesList(pydantic.BaseModel):
@@ -30,6 +31,8 @@ class UsernamesList(pydantic.BaseModel):
 class CommissioningProposalsList(pydantic.BaseModel):
     count: int
     commissioning_proposals: list[str]
+    beamline: str | None = None
+    facility: FacilityName | None = None
 
 
 class CycleProposalList(pydantic.BaseModel):

--- a/src/nsls2api/api/v1/proposal_api.py
+++ b/src/nsls2api/api/v1/proposal_api.py
@@ -42,9 +42,27 @@ async def get_recent_proposals(count: int, beamline: str | None = None):
 
 
 @router.get("/proposals/commissioning", response_model=CommissioningProposalsList)
-async def get_commissioning_proposals(beamline: str | None = None, facility: FacilityName | None = None):
+async def get_commissioning_proposals(
+    beamline: str | None = None, facility: FacilityName | None = None
+):
+    """
+    Get a list of commissioning proposals.  If a beamline is provided, only proposals
+    for that beamline will be returned and the facility will be ignored.
+
+    Args:
+        beamline (str optional): The beamline to filter proposals by.
+        facility (FacilityName optional): The facility to filter proposals by.
+
+    Returns:
+        CommissioningProposalsList: A list of commissioning proposals.
+
+    Raises:
+        HTTPException: If no commissioning proposals are found or an error occurs.
+    """
     try:
-        proposals = await proposal_service.commissioning_proposals(beamline=beamline, facility=facility)
+        proposals = await proposal_service.commissioning_proposals(
+            beamline=beamline, facility=facility
+        )
         if proposals is None:
             raise HTTPException(
                 status_code=fastapi.status.HTTP_404_NOT_FOUND,

--- a/src/nsls2api/api/v1/proposal_api.py
+++ b/src/nsls2api/api/v1/proposal_api.py
@@ -42,9 +42,9 @@ async def get_recent_proposals(count: int, beamline: str | None = None):
 
 
 @router.get("/proposals/commissioning", response_model=CommissioningProposalsList)
-async def get_commissioning_proposals(beamline: str | None = None):
+async def get_commissioning_proposals(beamline: str | None = None, facility: FacilityName | None = None):
     try:
-        proposals = await proposal_service.commissioning_proposals(beamline=beamline)
+        proposals = await proposal_service.commissioning_proposals(beamline=beamline, facility=facility)
         if proposals is None:
             raise HTTPException(
                 status_code=fastapi.status.HTTP_404_NOT_FOUND,
@@ -60,10 +60,7 @@ async def get_commissioning_proposals(beamline: str | None = None):
             detail=f"An error occurred: {e}",
         )
 
-    model = CommissioningProposalsList(
-        count=len(proposals), commissioning_proposals=proposals
-    )
-    return model
+    return proposals
 
 
 @router.get(

--- a/src/nsls2api/services/pass_service.py
+++ b/src/nsls2api/services/pass_service.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 from nsls2api.api.models.facility_model import FacilityName
 from nsls2api.infrastructure import config
 from nsls2api.infrastructure.logging import logger
+from nsls2api.models.proposal_types import ProposalType
 from nsls2api.services.helpers import httpx_client_wrapper
 from nsls2api.models.cycles import Cycle
 from nsls2api.models.pass_models import (
@@ -88,6 +89,25 @@ async def get_proposal_types(
         raise PassException(error_message) from error
 
     return proposal_types
+
+
+async def get_commissioning_proposal_type(
+    facility: FacilityName = FacilityName.nsls2,
+) -> Optional[ProposalType]:
+    match facility:
+        case FacilityName.nsls2:
+            # The PASS ID for NSLS-II commissioning proposals is 300005
+            proposal = await ProposalType.find_one(ProposalType.pass_id == "300005")
+            return proposal
+        case FacilityName.lbms:
+            # The PASS ID for LBMS commissioning proposals is 300042
+            proposal = await ProposalType.find_one(ProposalType.pass_id == "300042")
+            return proposal
+        case FacilityName.cfn:
+            return None
+            # We don't have a commissioning proposal type for CFN
+        case _:
+            raise ValueError(f"Unknown facility: {facility}")
 
 
 async def get_saf_from_proposal(

--- a/src/nsls2api/services/proposal_service.py
+++ b/src/nsls2api/services/proposal_service.py
@@ -320,6 +320,8 @@ async def is_commissioning(proposal: Proposal):
     return (
         proposal.pass_type_id == "300005"
         or proposal.type == "Beamline Commissioning (beamline staff only)"
+        or proposal.pass_type_id == "300042"
+        or proposal.type == "Commissioning (staff only)"
     )
 
 

--- a/src/nsls2api/services/proposal_service.py
+++ b/src/nsls2api/services/proposal_service.py
@@ -6,12 +6,13 @@ import random
 from typing import Optional
 
 from beanie.odm.operators.find.array import ElemMatch
-from beanie.operators import And, In, RegEx, Text
+from beanie.operators import And, In, RegEx, Text, Or
 
 from nsls2api.api.models.facility_model import FacilityName
 from nsls2api.api.models.proposal_model import (
     ProposalDiagnostics,
     ProposalFullDetails,
+    CommissioningProposalsList,
 )
 from nsls2api.infrastructure.logging import logger
 from nsls2api.models.cycles import Cycle
@@ -21,6 +22,7 @@ from nsls2api.services import (
     bnlpeople_service,
     beamline_service,
     facility_service,
+    pass_service,
 )
 
 
@@ -284,24 +286,49 @@ async def pi_from_proposal(proposal_id: str) -> Optional[list[User]]:
 
 
 # TODO: There seems to be a data integrity issue that not all commissioning proposals have a beamline listed.
-async def commissioning_proposals(beamline: str | None = None):
+async def commissioning_proposals(beamline: str | None = None, facility: FacilityName | None = None) -> CommissioningProposalsList:
+
+    commissioning_proposal_list = []
+    proposals = None
+    query_on_facility = None
+    query_on_beamline = None
+
+    # TODO: replace this with a function call that will return all the commissioning proposal types
+    commissioning_proposal_types = ["300005", "300042"]
+
+    query = Or(*[Proposal.pass_type_id == proposal_type for proposal_type in commissioning_proposal_types])
+
+    # if there is a beamline specified then this will take precedence
     if beamline:
         # Ensure we match the case in the database for the beamline name
-        beamline = beamline.upper()
-
-        proposals = Proposal.find(In(Proposal.instruments, [beamline])).find(
-            Proposal.pass_type_id == "300005"
+        query_on_beamline = beamline.upper()
+        proposals = Proposal.find(In(Proposal.instruments, [query_on_beamline])).find(
+            query, projection_model=ProposalIdView
         )
+
+    elif facility:
+        # look up the pass proposal type id for commissioning proposals for this facility
+        query_on_facility = facility
+        proposal_type : ProposalType = await pass_service.get_commissioning_proposal_type(query_on_facility)
+        print(f"Found proposal type {proposal_type}")
+        if proposal_type:
+            proposals = Proposal.find(Proposal.pass_type_id == proposal_type.pass_id, projection_model=ProposalIdView)
     else:
         proposals = Proposal.find(
-            Proposal.pass_type_id == "300005", projection_model=ProposalIdView
+            query, projection_model=ProposalIdView
         )
 
-    commissioning_proposal_list = [
-        p.proposal_id for p in await proposals.to_list() if p.proposal_id is not None
-    ]
+    if proposals:
+        commissioning_proposal_list = [
+            p.proposal_id for p in await proposals.to_list() if p.proposal_id is not None
+        ]
 
-    return commissioning_proposal_list
+    model = CommissioningProposalsList(count=len(commissioning_proposal_list),
+                                                 commissioning_proposals=commissioning_proposal_list,
+                                                 beamline=query_on_beamline,
+                                                 facility=query_on_facility)
+
+    return model
 
 
 async def has_valid_cycle(proposal: Proposal):
@@ -310,8 +337,8 @@ async def has_valid_cycle(proposal: Proposal):
     return not (
         (len(proposal.cycles) == 0)
         and (
-            proposal.pass_type_id != 300005
-            or proposal.type == "Beamline Commissioning (beamline staff only)"
+            proposal.pass_type_id != "300005"
+            or proposal.pass_type_id != "300042"
         )
     )
 
@@ -319,9 +346,7 @@ async def has_valid_cycle(proposal: Proposal):
 async def is_commissioning(proposal: Proposal):
     return (
         proposal.pass_type_id == "300005"
-        or proposal.type == "Beamline Commissioning (beamline staff only)"
         or proposal.pass_type_id == "300042"
-        or proposal.type == "Commissioning (staff only)"
     )
 
 


### PR DESCRIPTION
This PR adds in support to deal with LBMS facilities commissioning proposals.

There are a number of places that this code can be improved by removing hard coded values for the PASS IDs for the respective commissioning proposal types (I've created an issue #146 )

Testing on my local dev instance... 

http://127.0.0.1:8000/v1/proposals/commissioning?facility=lbms
```json
{
  "count": 0,
  "commissioning_proposals": [],
  "beamline": null,
  "facility": "lbms"
}
```

http://127.0.0.1:8000/v1/proposals/commissioning?facility=nsls2
```json
{
  "count": 30,
  "commissioning_proposals": [
   "311955",
    "312922",
    "311272",
    ...
    <truncated list>
    ...
    "312051",
    "313772"
  ],
  "beamline": null,
  "facility": "nsls2"

}
```

http://127.0.0.1:8000/v1/proposals/commissioning?facility=cfn
```json
{
  "count": 0,
  "commissioning_proposals": [],
  "beamline": null,
  "facility": "cfn"
}
```

And with no facility parameter... http://127.0.0.1:8000/v1/proposals/commissioning
```json
{
  "count": 34,
  "commissioning_proposals": [
    "311955",
    "312922",
    "311272",
    ...
    <truncated list>
    ...
    "317763",
    "317764"
  ],
  "beamline": null,
  "facility": null
}
```

And specifying a beamline http://127.0.0.1:8000/v1/proposals/commissioning?beamline=PDF
```json
{
  "count": 1,
  "commissioning_proposals": [
    "312977"
  ],
  "beamline": "PDF",
  "facility": null
}
```

Which still gives the same answer if we select the wrong facility for the beam line 
http://127.0.0.1:8000/v1/proposals/commissioning?beamline=PDF&facility=lbms
```json
{
  "count": 1,
  "commissioning_proposals": [
    "312977"
  ],
  "beamline": "PDF",
  "facility": null
}
```

I think that this will also fix #140 