### PR TITLE
Bug fixes for Slack channel creation workflow

### DIFF
--- a/integration-tests/check_all_beamlines.http
+++ b/integration-tests/check_all_beamlines.http
@@ -17,7 +17,7 @@ Accept: application/json
 
 > {%
     client.test("Request executed successfully", function () {
-        client.assert(response.status === 451, "ARI should not exist yet!");
+        client.assert(response.status === 404, "ARI should not exist yet!");
     });
 %}
 
@@ -40,7 +40,7 @@ Accept: application/json
 
 > {%
     client.test("Request executed successfully", function () {
-        client.assert(response.status === 451, "CDI should not exist yet!");
+        client.assert(response.status === 404, "CDI should not exist yet!");
     });
 %}
 
@@ -305,7 +305,7 @@ Accept: application/json
 
 > {%
     client.test("Request executed successfully", function () {
-        client.assert(response.status === 451, "SXN should not exist yet!");
+        client.assert(response.status === 404, "SXN should not exist yet!");
     });
 %}
 

--- a/src/nsls2api/infrastructure/config.py
+++ b/src/nsls2api/infrastructure/config.py
@@ -56,7 +56,7 @@ class Settings(BaseSettings):
 
     # Slack settings
     slack_bot_token: str | None = ""
-    superadmin_slack_user_token: str | None = ""
+    slack_admin_user_token: str | None = ""
     slack_signing_secret: str | None = ""
     nsls2_workspace_team_id: str | None = ""
 

--- a/src/nsls2api/services/slack_service.py
+++ b/src/nsls2api/services/slack_service.py
@@ -431,7 +431,9 @@ async def create_proposal_channels(
         logger.info(
             f"Found {len(user_ids)} users to invite: {user_ids} to channel '{channel_name}' (ID: {channel_id})"
         )
-        conversation_invite(channel_id, user_ids)
+        if len(user_ids) > 0:
+            # If we don't have any users to invite - then don't invite them.
+            conversation_invite(channel_id, user_ids)
 
         channels_created.append(proposal_channel)
 

--- a/src/nsls2api/services/slack_service.py
+++ b/src/nsls2api/services/slack_service.py
@@ -432,7 +432,7 @@ async def create_proposal_channels(
             f"Found {len(user_ids)} users to invite: {user_ids} to channel '{channel_name}' (ID: {channel_id})"
         )
         if len(user_ids) > 0:
-            # If we don't have any users to invite - then don't invite them.
+            # Only invite users to the channel when we have some to invite.
             conversation_invite(channel_id, user_ids)
 
         channels_created.append(proposal_channel)


### PR DESCRIPTION
This PR addresses a few small issues found while testing on BMM.  

- Add back in admin credentials to allow to invite users to the nsls2 slack workspace
- If all the users are already in the channel, then don't try to invite a blank list.
- Tolerate expected errors thrown by Slack API when we can't find a user by email yet.

As an unconnected commit, I'm also correcting the http response code for non-existent beamlines. 