### PR TITLE
Fix /stats endpoint

### DIFF
--- a/src/nsls2api/api/v1/stats_api.py
+++ b/src/nsls2api/api/v1/stats_api.py
@@ -20,7 +20,7 @@ async def stats():
     total_proposals = await proposal_service.proposal_count()
     beamlines = await beamline_service.beamline_count()
     facilities = await facility_service.facilities_count()
-    commissioning = len(await proposal_service.commissioning_proposals())
+    commissioning_proposals = await proposal_service.commissioning_proposals()
 
     nsls2_data_health = await facility_service.is_healthy("nsls2")
 
@@ -52,7 +52,7 @@ async def stats():
         facility_count=facilities,
         beamline_count=beamlines,
         proposal_count=total_proposals,
-        commissioning_proposal_count=commissioning,
+        commissioning_proposal_count=commissioning_proposals.count,
         nsls2_data_health=nsls2_data_health,
         lbms_data_health=lbms_data_health,
         nsls2_proposals_per_cycle=nsls2_proposals_per_cycle,


### PR DESCRIPTION
The `/stats` endpoint is currently broken - hopefully this fixes it. 