### PR TITLE
Add admin role validation dependency to Slack channels creation endpoint

### DIFF
--- a/src/nsls2api/api/v1/proposal_api.py
+++ b/src/nsls2api/api/v1/proposal_api.py
@@ -281,7 +281,10 @@ async def get_slack_channels_for_proposal(
     return channels
 
 
-@router.post("/proposal/{proposal_id}/slack-channels")
+@router.post(
+    "/proposal/{proposal_id}/slack-channels",
+    dependencies=[Depends(validate_admin_role)],
+)
 async def create_slack_channels_for_proposal(
     proposal_id: str,
 ) -> list[ProposalSlackChannel]:


### PR DESCRIPTION
Only allow admins to create slack channels