### PR TITLE
Fix problem when LBMS database has not synchronized

### DIFF
--- a/src/nsls2api/api/v1/stats_api.py
+++ b/src/nsls2api/api/v1/stats_api.py
@@ -1,6 +1,8 @@
 import fastapi
 
 from nsls2api._version import version as api_version
+from nsls2api.infrastructure.logging import logger
+from nsls2api.api.models.facility_model import FacilityName
 from nsls2api.api.models.stats_model import (
     AboutModel,
     ProposalsPerCycleModel,
@@ -28,25 +30,32 @@ async def stats():
     nsls2_proposals_per_cycle: list[ProposalsPerCycleModel] = []
     nsls2_cycle_list = await facility_service.facility_cycles("nsls2")
     for cycle in nsls2_cycle_list:
-        proposal_list = await proposal_service.fetch_proposals_for_cycle(cycle)
-        if proposal_list is not None:
-            model = ProposalsPerCycleModel(
-                cycle=cycle, proposal_count=len(proposal_list)
-            )
-            nsls2_proposals_per_cycle.append(model)
+        try:
+            # Fetch proposals for the cycle
+            proposal_list = await proposal_service.fetch_proposals_for_cycle(cycle)
+            if proposal_list is not None:
+                # Create a model for the cycle and proposal count
+                model = ProposalsPerCycleModel(cycle=cycle, proposal_count=len(proposal_list))
+                nsls2_proposals_per_cycle.append(model)
+        except LookupError as e:
+            # Handle the case where the cycle is not found
+            logger.error(f"Cycle {cycle} not found for NSLS-II facility.")
+            continue
 
     lbms_data_health = await facility_service.is_healthy("lbms")
-
     # Get the LBMS proposals per cycle
     lbms_proposals_per_cycle: list[ProposalsPerCycleModel] = []
     lbms_cycle_list = await facility_service.facility_cycles("lbms")
     for cycle in lbms_cycle_list:
-        proposal_list = await proposal_service.fetch_proposals_for_cycle(cycle)
-        if proposal_list is not None:
-            model = ProposalsPerCycleModel(
-                cycle=cycle, proposal_count=len(proposal_list)
-            )
-            lbms_proposals_per_cycle.append(model)
+        try:
+            proposal_list = await proposal_service.fetch_proposals_for_cycle(cycle, facility_name=FacilityName.lbms)
+            if proposal_list is not None:
+                model = ProposalsPerCycleModel(cycle=cycle, proposal_count=len(proposal_list))
+                lbms_proposals_per_cycle.append(model)
+        except LookupError as e:
+            # Handle the case where the cycle is not found
+            logger.error(f"Cycle {cycle} not found for LBMS facility.")
+            continue
 
     model = StatsModel(
         facility_count=facilities,
@@ -59,7 +68,6 @@ async def stats():
         lbms_proposals_per_cycle=lbms_proposals_per_cycle,
     )
     return model
-
 
 @router.get("/about", response_model=AboutModel)
 async def about():


### PR DESCRIPTION
Add some error handling for when the underlying database does not contain the cycle details for a facility - this usually happens when the synchronization is not working. 

There was also a bug in the code that wasn't actually getting the list of cycles for lbms facility but getting them for nsls2 instead. 