### PR TITLE
Make the invitation of slack users more robust

### DIFF
--- a/src/nsls2api/services/slack_service.py
+++ b/src/nsls2api/services/slack_service.py
@@ -75,12 +75,24 @@ def conversation_invite(channel_id: str, user_ids: list[str]):
     """
     client = WebClient(token=settings.slack_bot_token)
     try:
-        response = client.conversations_invite(channel=channel_id, users=user_ids)
+        response = client.conversations_invite(
+            channel=channel_id, users=user_ids, force=True
+        )
         if response.get("ok"):
             logger.info(f"Invited users {user_ids} to channel '{channel_id}'.")
     except SlackApiError as error:
         # If the error is that the user is already in the channel, we can ignore it
         if error.response["error"] == "already_in_channel":
+            return
+        if error.response["error"] == "user_is_ultra_restricted":
+            detailed_errors = error.response.get("errors", [])
+            problem_users = []
+            for detailed_error in detailed_errors:
+                if detailed_error.get("error") == "user_is_ultra_restricted":
+                    problem_users.append(detailed_error.get("user"))
+            logger.error(
+                f"User(s) {problem_users} are ultra-restricted and cannot be invited to channel '{channel_id}'."
+            )
             return
         logger.exception(error)
 
@@ -333,7 +345,7 @@ def get_userid_by_username(username: str) -> Optional[str]:
     return None  # Not found
 
 
-def invite_newuser_to_channel(channel: str, email: str):
+def invite_newuser_to_channel(channel: str, email: str) -> Optional[str]:
     """
     Invites a user to the workspace/channel.
     Args:
@@ -341,15 +353,21 @@ def invite_newuser_to_channel(channel: str, email: str):
         email (str): The email address of the user.
 
     Returns:
-
+        str | None: The user_id of the invited user if successful, None otherwise.
     """
     try:
         client = WebClient(token=settings.slack_admin_user_token)
         response = client.admin_users_invite(
-            team_id=settings.nsls2_workspace_team_id, email=email, channel_ids=channel
+            team_id=settings.nsls2_workspace_team_id,
+            email=email,
+            channel_ids=channel,
         )
         if response.get("ok"):
-            return response
+            # If the user invite was ok, then lets look up the user_id of the newly invited user
+            new_user = lookup_user_by_email(email)
+            if new_user:
+                return new_user.user_id
+            return
     except SlackApiError as error:
         if error.response["error"] == "already_in_team_invited_user":
             # We've already invited this user - so we are good.
@@ -456,14 +474,17 @@ async def create_proposal_channels(
             user = lookup_user_by_email(email)
             if user:
                 user_ids.append(user.user_id)
-                # Store the user in the proposal channel object
-                proposal_channel.users.append(user)
             else:
                 # We need to invite user into the channels (and workspace)
                 logger.info(
                     f"Inviting user {email} to channel '{channel_name}' (ID: {channel_id})"
                 )
-                invite_newuser_to_channel(channel_id, email)
+                new_user_id = invite_newuser_to_channel(channel_id, email)
+                if new_user_id:
+                    user_ids.append(new_user_id)
+
+            # Store the user in the proposal channel object
+            proposal_channel.users.append(user)
 
         logger.info(
             f"Found {len(user_ids)} users to invite: {user_ids} to channel '{channel_name}' (ID: {channel_id})"

--- a/src/nsls2api/services/slack_service.py
+++ b/src/nsls2api/services/slack_service.py
@@ -330,7 +330,7 @@ def get_userid_by_username(username: str) -> Optional[str]:
     client = WebClient(token=settings.slack_bot_token)
     response = client.users_list()
     if not response["ok"]:
-        raise Exception("Failed to fetch users")
+        raise SlackApiError(response=response)
 
     for member in response["members"]:
         if member.get("name") == username:

--- a/src/nsls2api/services/slack_service.py
+++ b/src/nsls2api/services/slack_service.py
@@ -326,13 +326,18 @@ def get_userid_by_username(username: str) -> Optional[str]:
                           the user if found, None otherwise.
     """
     client = WebClient(token=settings.slack_bot_token)
-    response = client.users_list()
-    if not response["ok"]:
-        raise SlackApiError(response=response)
+    try:
+        response = client.users_list()
+        if not response["ok"]:
+            logger.error(f"Slack API returned an error: {response}")
+            return None
 
-    for member in response["members"]:
-        if member.get("name") == username:
-            return member["id"]
+        for member in response["members"]:
+            if member.get("name") == username:
+                return member["id"]
+    except SlackApiError as error:
+        logger.exception(f"Failed to retrieve users list: {error}")
+        return None
 
     return None  # Not found
 

--- a/src/nsls2api/services/slack_service.py
+++ b/src/nsls2api/services/slack_service.py
@@ -13,8 +13,6 @@ from nsls2api.models.slack_models import (
     SlackUser,
 )
 from nsls2api.services import beamline_service, proposal_service
-from abc import ABC, abstractmethod
-
 settings = get_settings()
 
 

--- a/src/nsls2api/services/slack_service.py
+++ b/src/nsls2api/services/slack_service.py
@@ -13,12 +13,22 @@ from nsls2api.models.slack_models import (
     SlackUser,
 )
 from nsls2api.services import beamline_service, proposal_service
+from abc import ABC, abstractmethod
 
 settings = get_settings()
 
 
 class ChannelAlreadyExistsError(Exception):
     pass
+
+class AbstractSlackService(ABC):
+    """Abstract base class for Slack services."""
+    @abstractmethod
+    async def create_proposal_channels(self, proposal_id: str) -> list[ProposalSlackChannel] | None:
+        pass
+
+
+
 
 
 def create_conversation(name: str, is_private: bool = True) -> str | None:

--- a/src/nsls2api/services/slack_service.py
+++ b/src/nsls2api/services/slack_service.py
@@ -167,6 +167,9 @@ def get_user_info(user_id: str) -> Optional[SlackUser]:
     """
     Retrieves the details of a Slack User .
 
+    Args:
+        user_id (str) : Slack user_id to lookup
+
     Returns:
         SlackUser: An instance of the SlackUser class containing the user details.
     """

--- a/src/nsls2api/services/slack_service.py
+++ b/src/nsls2api/services/slack_service.py
@@ -21,15 +21,6 @@ settings = get_settings()
 class ChannelAlreadyExistsError(Exception):
     pass
 
-class AbstractSlackService(ABC):
-    """Abstract base class for Slack services."""
-    @abstractmethod
-    async def create_proposal_channels(self, proposal_id: str) -> list[ProposalSlackChannel] | None:
-        pass
-
-
-
-
 
 def create_conversation(name: str, is_private: bool = True) -> str | None:
     """

--- a/src/nsls2api/services/slack_service.py
+++ b/src/nsls2api/services/slack_service.py
@@ -310,6 +310,29 @@ def lookup_user_by_email(email: str) -> SlackPerson | None:
     return None
 
 
+def get_userid_by_username(username: str) -> Optional[str]:
+    """
+    Looks up the slack user_id associated with the given username.
+
+    Args:
+        username (str): The username of the user.
+
+    Returns:
+        str | None: A string containing the user_id of
+                          the user if found, None otherwise.
+    """
+    client = WebClient(token=settings.slack_bot_token)
+    response = client.users_list()
+    if not response["ok"]:
+        raise Exception("Failed to fetch users")
+
+    for member in response["members"]:
+        if member.get("name") == username:
+            return member["id"]
+
+    return None  # Not found
+
+
 def invite_newuser_to_channel(channel: str, email: str):
     """
     Invites a user to the workspace/channel.

--- a/src/nsls2api/services/slack_service.py
+++ b/src/nsls2api/services/slack_service.py
@@ -394,6 +394,7 @@ async def create_proposal_channels(
                 )
                 # Now let's add the beamline Slack channel managers to the channel
                 conversation_invite(channel_id, verified_manager_ids)
+                # And store the verified managers in the proposal channel object
                 proposal_channel.managers.extend(verified_managers)
 
             beamline_slack_bot = verify_slack_bot(
@@ -408,7 +409,9 @@ async def create_proposal_channels(
                 logger.info(
                     f"Adding these beamline bots to the channel: {beamline_slack_bot}"
                 )
+                # Now lets invite the beamline bot to the channel
                 conversation_invite(channel_id, [beamline_slack_bot.user_id])
+                # And store the verified bot in the proposal channel object
                 proposal_channel.bots.append(beamline_slack_bot)
             else:
                 logger.info(f"No slack bot found for beamline {beamline}")
@@ -420,6 +423,7 @@ async def create_proposal_channels(
             user = lookup_user_by_email(email)
             if user:
                 user_ids.append(user.user_id)
+                # Store the user in the proposal channel object
                 proposal_channel.users.append(user)
             else:
                 # We need to invite user into the channels (and workspace)


### PR DESCRIPTION
For users that need to be invited in the NSLS2 workspace, they will not appear as a member of the channel that they are invited into until they accept the invite, but for any additional channels that we add the user to they will appear instantly.  In order to avoid confusion this PR intends to, once the new user is invited to the workspace, we then also add it to the channel at the same time. 