### PR TITLE
Add experimental CLI tool

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 #    uv pip compile requirements-dev.in -o requirements-dev.txt
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.16
+aiohttp==3.11.18
     # via
     #   aiohttp-jinja2
     #   textual-dev
@@ -25,6 +25,8 @@ asyncer==0.0.8
     # via -r requirements-dev.in
 attrs==25.3.0
     # via aiohttp
+bidict==0.23.1
+    # via python-socketio
 black==25.1.0
     # via -r requirements-dev.in
 blinker==1.9.0
@@ -33,7 +35,7 @@ brotli==1.1.0
     # via geventhttpclient
 bunnet==1.3.0
     # via -r requirements-dev.in
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   geventhttpclient
     #   httpcore
@@ -41,7 +43,7 @@ certifi==2025.1.31
     #   requests
 cfgv==3.4.0
     # via pre-commit
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
 click==8.1.8
     # via
@@ -52,7 +54,9 @@ click==8.1.8
     #   textual-dev
     #   userpath
 configargparse==1.7
-    # via locust
+    # via
+    #   locust
+    #   locust-cloud
 coverage==7.8.0
     # via -r requirements-dev.in
 decorator==5.2.1
@@ -74,7 +78,7 @@ flask-cors==5.0.1
     # via locust
 flask-login==0.6.3
     # via locust
-frozenlist==1.5.0
+frozenlist==1.6.0
     # via
     #   aiohttp
     #   aiosignal
@@ -82,12 +86,15 @@ gevent==24.11.1
     # via
     #   geventhttpclient
     #   locust
+    #   locust-cloud
 geventhttpclient==2.3.3
     # via locust
-greenlet==3.2.0
+greenlet==3.2.1
     # via gevent
-h11==0.14.0
-    # via httpcore
+h11==0.16.0
+    # via
+    #   httpcore
+    #   wsproto
 hatch==1.14.1
     # via -r requirements-dev.in
 hatch-requirements-txt==0.4.1
@@ -100,13 +107,13 @@ hatchling==1.27.0
     #   hatch
     #   hatch-requirements-txt
     #   hatch-vcs
-httpcore==1.0.8
+httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via hatch
 hyperlink==21.0.0
     # via hatch
-identify==2.6.9
+identify==2.6.10
     # via pre-commit
 idna==3.10
     # via
@@ -117,7 +124,7 @@ idna==3.10
     #   yarl
 iniconfig==2.1.0
     # via pytest
-ipython==9.1.0
+ipython==9.2.0
     # via -r requirements-dev.in
 ipython-pygments-lexers==1.1.1
     # via ipython
@@ -142,8 +149,10 @@ lazy-model==0.2.0
     # via bunnet
 linkify-it-py==2.0.3
     # via markdown-it-py
-locust==2.35.0
+locust==2.36.2
     # via -r requirements-dev.in
+locust-cloud==1.20.7
+    # via locust
 markdown-it-py==3.0.0
     # via
     #   mdit-py-plugins
@@ -159,7 +168,7 @@ mdit-py-plugins==0.4.2
     # via markdown-it-py
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.6.0
+more-itertools==10.7.0
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -171,13 +180,13 @@ multidict==6.4.3
     # via
     #   aiohttp
     #   yarl
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via black
 nodeenv==1.9.1
     # via
     #   pre-commit
     #   pyright
-packaging==24.2
+packaging==25.0
     # via
     #   black
     #   hatch
@@ -199,6 +208,7 @@ platformdirs==4.3.7
     # via
     #   black
     #   hatch
+    #   locust-cloud
     #   textual
     #   virtualenv
 pluggy==1.5.0
@@ -221,20 +231,20 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pydantic==2.11.3
+pydantic==2.11.4
     # via
     #   bunnet
     #   lazy-model
-pydantic-core==2.33.1
+pydantic-core==2.33.2
     # via pydantic
 pygments==2.19.1
     # via
     #   ipython
     #   ipython-pygments-lexers
     #   rich
-pymongo==4.12.0
+pymongo==4.12.1
     # via bunnet
-pyright==1.1.399
+pyright==1.1.400
     # via -r requirements-dev.in
 pytest==8.3.5
     # via
@@ -242,36 +252,44 @@ pytest==8.3.5
     #   pytest-asyncio
 pytest-asyncio==0.26.0
     # via -r requirements-dev.in
+python-engineio==4.12.0
+    # via python-socketio
+python-socketio==5.13.0
+    # via locust-cloud
 pyyaml==6.0.2
     # via pre-commit
 pyzmq==26.4.0
     # via locust
 requests==2.32.3
-    # via locust
+    # via
+    #   locust
+    #   python-socketio
 rich==14.0.0
     # via
     #   hatch
     #   textual
     #   textual-serve
-ruff==0.11.5
+ruff==0.11.8
     # via -r requirements-dev.in
-setuptools==78.1.0
+setuptools==80.1.0
     # via
     #   locust
     #   setuptools-scm
     #   zope-event
     #   zope-interface
-setuptools-scm==8.2.0
+setuptools-scm==8.3.1
     # via hatch-vcs
 shellingham==1.5.4
     # via hatch
+simple-websocket==1.1.0
+    # via python-engineio
 sniffio==1.3.1
     # via
     #   anyio
     #   asgi-lifespan
 stack-data==0.6.3
     # via ipython
-textual==3.1.0
+textual==3.2.0
     # via
     #   textual-dev
     #   textual-serve
@@ -289,7 +307,7 @@ traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-trove-classifiers==2025.4.11.15
+trove-classifiers==2025.5.1.12
     # via hatchling
 typing-extensions==4.13.2
     # via
@@ -310,7 +328,7 @@ urllib3==2.4.0
     #   requests
 userpath==1.9.2
     # via hatch
-uv==0.6.14
+uv==0.7.2
     # via
     #   -r requirements-dev.in
     #   hatch
@@ -321,12 +339,16 @@ virtualenv==20.30.0
     #   pre-commit
 wcwidth==0.2.13
     # via prompt-toolkit
+websocket-client==1.8.0
+    # via python-socketio
 werkzeug==3.1.3
     # via
     #   flask
     #   flask-cors
     #   flask-login
     #   locust
+wsproto==1.2.0
+    # via simple-websocket
 yarl==1.20.0
     # via aiohttp
 zope-event==5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -84,7 +84,7 @@ gevent==24.11.1
     #   locust
 geventhttpclient==2.3.3
     # via locust
-greenlet==3.1.1
+greenlet==3.2.0
     # via gevent
 h11==0.14.0
     # via httpcore
@@ -100,7 +100,7 @@ hatchling==1.27.0
     #   hatch
     #   hatch-requirements-txt
     #   hatch-vcs
-httpcore==1.0.7
+httpcore==1.0.8
     # via httpx
 httpx==0.28.1
     # via hatch
@@ -142,7 +142,7 @@ lazy-model==0.2.0
     # via bunnet
 linkify-it-py==2.0.3
     # via markdown-it-py
-locust==2.34.1
+locust==2.35.0
     # via -r requirements-dev.in
 markdown-it-py==3.0.0
     # via
@@ -167,7 +167,7 @@ msgpack==1.1.0
     # via
     #   locust
     #   textual-dev
-multidict==6.2.0
+multidict==6.4.3
     # via
     #   aiohttp
     #   yarl
@@ -209,7 +209,7 @@ pre-commit==4.2.0
     # via pre-commit-uv
 pre-commit-uv==4.1.4
     # via -r requirements-dev.in
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via ipython
 propcache==0.3.1
     # via
@@ -234,7 +234,7 @@ pygments==2.19.1
     #   rich
 pymongo==4.12.0
     # via bunnet
-pyright==1.1.398
+pyright==1.1.399
     # via -r requirements-dev.in
 pytest==8.3.5
     # via
@@ -253,7 +253,7 @@ rich==14.0.0
     #   hatch
     #   textual
     #   textual-serve
-ruff==0.11.4
+ruff==0.11.5
     # via -r requirements-dev.in
 setuptools==78.1.0
     # via
@@ -271,13 +271,13 @@ sniffio==1.3.1
     #   asgi-lifespan
 stack-data==0.6.3
     # via ipython
-textual==3.0.1
+textual==3.1.0
     # via
     #   textual-dev
     #   textual-serve
 textual-dev==1.7.0
     # via -r requirements-dev.in
-textual-serve==1.1.1
+textual-serve==1.1.2
     # via textual-dev
 toml==0.10.2
     # via bunnet
@@ -289,9 +289,9 @@ traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-trove-classifiers==2025.3.19.19
+trove-classifiers==2025.4.11.15
     # via hatchling
-typing-extensions==4.13.1
+typing-extensions==4.13.2
     # via
     #   anyio
     #   pydantic
@@ -304,13 +304,13 @@ typing-inspection==0.4.0
     # via pydantic
 uc-micro-py==1.0.3
     # via linkify-it-py
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   geventhttpclient
     #   requests
 userpath==1.9.2
     # via hatch
-uv==0.6.13
+uv==0.6.14
     # via
     #   -r requirements-dev.in
     #   hatch
@@ -327,7 +327,7 @@ werkzeug==3.1.3
     #   flask-cors
     #   flask-login
     #   locust
-yarl==1.19.0
+yarl==1.20.0
     # via aiohttp
 zope-event==5.0
     # via gevent

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==1.0.7
+httpcore==1.0.8
     # via
     #   httpx
     #   httpx-socks
@@ -148,18 +148,18 @@ slack-sdk==3.35.0
     #   slack-bolt
 sniffio==1.3.1
     # via anyio
-starlette==0.46.1
+starlette==0.46.2
     # via
     #   asgi-correlation-id
     #   fastapi
     #   prometheus-fastapi-instrumentator
-textual==3.0.1
+textual==3.1.0
     # via -r requirements.in
 toml==0.10.2
     # via beanie
 typer==0.15.2
     # via -r requirements.in
-typing-extensions==4.13.1
+typing-extensions==4.13.2
     # via
     #   anyio
     #   beanie
@@ -177,7 +177,7 @@ uc-micro-py==1.0.3
     # via linkify-it-py
 uuid==1.30
     # via -r requirements.in
-uvicorn==0.34.0
+uvicorn==0.34.1
     # via -r requirements.in
 wcwidth==0.2.13
     # via prettytable

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ async-timeout==5.0.1
     # via httpx-socks
 beanie==1.29.0
     # via -r requirements.in
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   httpcore
     #   httpx
@@ -41,11 +41,11 @@ gssapi==1.9.0
     # via n2snusertools
 gunicorn==23.0.0
     # via -r requirements.in
-h11==0.14.0
+h11==0.16.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==1.0.8
+httpcore==1.0.9
     # via
     #   httpx
     #   httpx-socks
@@ -88,9 +88,9 @@ motor==3.7.0
     # via
     #   -r requirements.in
     #   beanie
-n2snusertools==0.3.7
+n2snusertools==0.3.9
     # via -r requirements.in
-packaging==24.2
+packaging==25.0
     # via
     #   asgi-correlation-id
     #   gunicorn
@@ -108,20 +108,20 @@ pyasn1==0.6.1
     # via ldap3
 pycparser==2.22
     # via cffi
-pydantic==2.11.3
+pydantic==2.11.4
     # via
     #   -r requirements.in
     #   beanie
     #   fastapi
     #   lazy-model
     #   pydantic-settings
-pydantic-core==2.33.1
+pydantic-core==2.33.2
     # via pydantic
-pydantic-settings==2.8.1
+pydantic-settings==2.9.1
     # via -r requirements.in
 pygments==2.19.1
     # via rich
-pymongo==4.12.0
+pymongo==4.12.1
     # via
     #   -r requirements.in
     #   motor
@@ -153,11 +153,11 @@ starlette==0.46.2
     #   asgi-correlation-id
     #   fastapi
     #   prometheus-fastapi-instrumentator
-textual==3.1.0
+textual==3.2.0
     # via -r requirements.in
 toml==0.10.2
     # via beanie
-typer==0.15.2
+typer==0.15.3
     # via -r requirements.in
 typing-extensions==4.13.2
     # via
@@ -170,14 +170,16 @@ typing-extensions==4.13.2
     #   typer
     #   typing-inspection
 typing-inspection==0.4.0
-    # via pydantic
+    # via
+    #   pydantic
+    #   pydantic-settings
 tzdata==2025.2
     # via faker
 uc-micro-py==1.0.3
     # via linkify-it-py
 uuid==1.30
     # via -r requirements.in
-uvicorn==0.34.1
+uvicorn==0.34.2
     # via -r requirements.in
 wcwidth==0.2.13
     # via prettytable

--- a/src/nsls2api/api/v1/beamline_api.py
+++ b/src/nsls2api/api/v1/beamline_api.py
@@ -271,3 +271,16 @@ async def add_beamline_service(name: str, service: BeamlineService):
         )
 
     return new_service
+
+@router.get("/beamlines")
+async def get_all_beamlines():
+    """
+    Get all beamlines.
+    """
+    beamlines = await beamline_service.all_beamlines()
+    if not beamlines:
+        raise HTTPException(
+            status_code=fastapi.status.HTTP_404_NOT_FOUND,
+            detail="No beamlines found",
+        )
+    return beamlines

--- a/src/nsls2api/api/v1/beamline_api.py
+++ b/src/nsls2api/api/v1/beamline_api.py
@@ -272,6 +272,7 @@ async def add_beamline_service(name: str, service: BeamlineService):
 
     return new_service
 
+
 @router.get("/beamlines")
 async def get_all_beamlines():
     """

--- a/src/nsls2api/api/v1/stats_api.py
+++ b/src/nsls2api/api/v1/stats_api.py
@@ -1,13 +1,13 @@
 import fastapi
 
 from nsls2api._version import version as api_version
-from nsls2api.infrastructure.logging import logger
 from nsls2api.api.models.facility_model import FacilityName
 from nsls2api.api.models.stats_model import (
     AboutModel,
     ProposalsPerCycleModel,
     StatsModel,
 )
+from nsls2api.infrastructure.logging import logger
 from nsls2api.services import (
     beamline_service,
     facility_service,
@@ -35,9 +35,11 @@ async def stats():
             proposal_list = await proposal_service.fetch_proposals_for_cycle(cycle)
             if proposal_list is not None:
                 # Create a model for the cycle and proposal count
-                model = ProposalsPerCycleModel(cycle=cycle, proposal_count=len(proposal_list))
+                model = ProposalsPerCycleModel(
+                    cycle=cycle, proposal_count=len(proposal_list)
+                )
                 nsls2_proposals_per_cycle.append(model)
-        except LookupError as e:
+        except LookupError:
             # Handle the case where the cycle is not found
             logger.error(f"Cycle {cycle} not found for NSLS-II facility.")
             continue
@@ -48,11 +50,15 @@ async def stats():
     lbms_cycle_list = await facility_service.facility_cycles("lbms")
     for cycle in lbms_cycle_list:
         try:
-            proposal_list = await proposal_service.fetch_proposals_for_cycle(cycle, facility_name=FacilityName.lbms)
+            proposal_list = await proposal_service.fetch_proposals_for_cycle(
+                cycle, facility_name=FacilityName.lbms
+            )
             if proposal_list is not None:
-                model = ProposalsPerCycleModel(cycle=cycle, proposal_count=len(proposal_list))
+                model = ProposalsPerCycleModel(
+                    cycle=cycle, proposal_count=len(proposal_list)
+                )
                 lbms_proposals_per_cycle.append(model)
-        except LookupError as e:
+        except LookupError:
             # Handle the case where the cycle is not found
             logger.error(f"Cycle {cycle} not found for LBMS facility.")
             continue
@@ -68,6 +74,7 @@ async def stats():
         lbms_proposals_per_cycle=lbms_proposals_per_cycle,
     )
     return model
+
 
 @router.get("/about", response_model=AboutModel)
 async def about():

--- a/src/nsls2api/cli/__init__.py
+++ b/src/nsls2api/cli/__init__.py
@@ -1,1 +1,0 @@
-__logged_in_username = None

--- a/src/nsls2api/cli/admin.py
+++ b/src/nsls2api/cli/admin.py
@@ -1,6 +1,14 @@
 import typer
 
-app = typer.Typer()
+from nsls2api.cli.utils.cli_helpers import auto_help_if_no_command
+
+app = typer.Typer(invoke_without_command=True)
+
+
+@app.callback()
+@auto_help_if_no_command()
+def admin_callback(ctx: typer.Context):
+    pass  # No need to call anything manually
 
 
 @app.command()

--- a/src/nsls2api/cli/api.py
+++ b/src/nsls2api/cli/api.py
@@ -1,13 +1,165 @@
+import httpx
 import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+from rich.theme import Theme
+from rich.box import ROUNDED
+
+from nsls2api.cli.settings import get_base_url, get_token
 
 app = typer.Typer()
+console = Console(theme=Theme({
+    "info": "cyan",
+    "warning": "yellow",
+    "error": "red bold",
+    "success": "green bold",
+    "health.good": "green bold",
+    "health.bad": "red bold",
+}))
 
 
 @app.command()
 def status():
-    print("General status of NSLS-II API")
+    """Show general status of NSLS-II API"""
+    url = f"{get_base_url()}/v1/about"
+
+    with console.status("[cyan]Fetching API status...", spinner="dots"):
+        try:
+            with httpx.Client() as client:
+                token = get_token()
+                headers = {"Authorization": f"{token}"} if token else {}
+                response = client.get(url, headers=headers)
+                response.raise_for_status()
+                about_data = response.json()
+
+                # Create status table
+                status_table = Table(show_header=False, box=None)
+                status_table.add_column("Key", style="cyan")
+                status_table.add_column("Value", style="green")
+
+                status_table.add_row("Status", "✓ Available")
+                status_table.add_row("Version", about_data["version"])
+                status_table.add_row("Description", about_data["description"])
+                status_table.add_row("API URL", get_base_url())
+
+                # Add container info if available
+                if "container_info" in about_data and about_data["container_info"]:
+                    status_table.add_row("Container", about_data["container_info"])
+
+                panel = Panel(
+                    status_table,
+                    title="NSLS-II API Status",
+                    border_style="green"
+                )
+                console.print(panel)
+
+        except httpx.HTTPStatusError as exc:
+            panel = Panel(
+                f"[error]HTTP Error: {exc.response.status_code} - {exc.response.reason_phrase}",
+                title="API Status Error",
+                border_style="red"
+            )
+            console.print(panel)
+        except httpx.RequestError as exc:
+            panel = Panel(
+                f"[error]Request Error: {exc}",
+                title="API Status Error",
+                border_style="red"
+            )
+            console.print(panel)
 
 
 @app.command()
 def metrics():
-    print("General metrics of NSLS-II API")
+    """Show general metrics of NSLS-II API"""
+    url = f"{get_base_url()}/v1/stats"
+
+    with console.status("[cyan]Fetching API metrics...", spinner="dots"):
+        try:
+            with httpx.Client() as client:
+                token = get_token()
+                headers = {"Authorization": f"{token}"} if token else {}
+                response = client.get(url, headers=headers)
+                response.raise_for_status()
+                stats_data = response.json()
+
+                # Create main metrics table
+                metrics_table = Table(show_header=False, box=None)
+                metrics_table.add_column("Key", style="cyan")
+                metrics_table.add_column("Value", style="green")
+
+                metrics_table.add_row("Facility Count", str(stats_data["facility_count"]))
+                metrics_table.add_row("Beamline Count", str(stats_data["beamline_count"]))
+                metrics_table.add_row("Proposal Count", str(stats_data["proposal_count"]))
+                metrics_table.add_row("Commissioning Proposal Count", str(stats_data["commissioning_proposal_count"]))
+
+                # Create health status table
+                health_table = Table(title="Data Health Status", box=ROUNDED)
+                health_table.add_column("Facility", style="cyan")
+                health_table.add_column("Status", style="green")
+
+                nsls2_health = stats_data["nsls2_data_health"]
+                lbms_health = stats_data["lbms_data_health"]
+
+                health_table.add_row(
+                    "NSLS-II",
+                    Text("✓ Healthy" if nsls2_health else "✗ Unhealthy", 
+                         style="health.good" if nsls2_health else "health.bad")
+                )
+                health_table.add_row(
+                    "LBMS",
+                    Text("✓ Healthy" if lbms_health else "✗ Unhealthy", 
+                         style="health.good" if lbms_health else "health.bad")
+                )
+
+                # Create NSLS-II proposals per cycle table
+                nsls2_table = Table(title="NSLS-II Proposals Per Cycle", box=ROUNDED)
+                nsls2_table.add_column("Cycle", style="cyan")
+                nsls2_table.add_column("Proposal Count", style="green", justify="right")
+
+                for cycle_data in stats_data["nsls2_proposals_per_cycle"]:
+                    nsls2_table.add_row(
+                        cycle_data["cycle"],
+                        str(cycle_data["proposal_count"])
+                    )
+
+                # Create LBMS proposals per cycle table
+                lbms_table = Table(title="LBMS Proposals Per Cycle", box=ROUNDED)
+                lbms_table.add_column("Cycle", style="cyan")
+                lbms_table.add_column("Proposal Count", style="green", justify="right")
+
+                for cycle_data in stats_data["lbms_proposals_per_cycle"]:
+                    lbms_table.add_row(
+                        cycle_data["cycle"],
+                        str(cycle_data["proposal_count"])
+                    )
+
+                # Create main panel
+                main_panel = Panel(
+                    metrics_table,
+                    title="NSLS-II API Metrics",
+                    border_style="green"
+                )
+
+                # Print all panels and tables
+                console.print(main_panel)
+                console.print(health_table)
+                console.print(nsls2_table)
+                console.print(lbms_table)
+
+        except httpx.HTTPStatusError as exc:
+            panel = Panel(
+                f"[error]HTTP Error: {exc.response.status_code} - {exc.response.reason_phrase}",
+                title="API Metrics Error",
+                border_style="red"
+            )
+            console.print(panel)
+        except httpx.RequestError as exc:
+            panel = Panel(
+                f"[error]Request Error: {exc}",
+                title="API Metrics Error",
+                border_style="red"
+            )
+            console.print(panel)

--- a/src/nsls2api/cli/api.py
+++ b/src/nsls2api/cli/api.py
@@ -1,23 +1,27 @@
 import httpx
 import typer
+from rich.box import ROUNDED
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 from rich.theme import Theme
-from rich.box import ROUNDED
 
 from nsls2api.cli.settings import get_base_url, get_token
 
 app = typer.Typer()
-console = Console(theme=Theme({
-    "info": "cyan",
-    "warning": "yellow",
-    "error": "red bold",
-    "success": "green bold",
-    "health.good": "green bold",
-    "health.bad": "red bold",
-}))
+console = Console(
+    theme=Theme(
+        {
+            "info": "cyan",
+            "warning": "yellow",
+            "error": "red bold",
+            "success": "green bold",
+            "health.good": "green bold",
+            "health.bad": "red bold",
+        }
+    )
+)
 
 
 @app.command()
@@ -49,9 +53,7 @@ def status():
                     status_table.add_row("Container", about_data["container_info"])
 
                 panel = Panel(
-                    status_table,
-                    title="NSLS-II API Status",
-                    border_style="green"
+                    status_table, title="NSLS-II API Status", border_style="green"
                 )
                 console.print(panel)
 
@@ -59,14 +61,14 @@ def status():
             panel = Panel(
                 f"[error]HTTP Error: {exc.response.status_code} - {exc.response.reason_phrase}",
                 title="API Status Error",
-                border_style="red"
+                border_style="red",
             )
             console.print(panel)
         except httpx.RequestError as exc:
             panel = Panel(
                 f"[error]Request Error: {exc}",
                 title="API Status Error",
-                border_style="red"
+                border_style="red",
             )
             console.print(panel)
 
@@ -90,10 +92,19 @@ def metrics():
                 metrics_table.add_column("Key", style="cyan")
                 metrics_table.add_column("Value", style="green")
 
-                metrics_table.add_row("Facility Count", str(stats_data["facility_count"]))
-                metrics_table.add_row("Beamline Count", str(stats_data["beamline_count"]))
-                metrics_table.add_row("Proposal Count", str(stats_data["proposal_count"]))
-                metrics_table.add_row("Commissioning Proposal Count", str(stats_data["commissioning_proposal_count"]))
+                metrics_table.add_row(
+                    "Facility Count", str(stats_data["facility_count"])
+                )
+                metrics_table.add_row(
+                    "Beamline Count", str(stats_data["beamline_count"])
+                )
+                metrics_table.add_row(
+                    "Proposal Count", str(stats_data["proposal_count"])
+                )
+                metrics_table.add_row(
+                    "Commissioning Proposal Count",
+                    str(stats_data["commissioning_proposal_count"]),
+                )
 
                 # Create health status table
                 health_table = Table(title="Data Health Status", box=ROUNDED)
@@ -105,13 +116,17 @@ def metrics():
 
                 health_table.add_row(
                     "NSLS-II",
-                    Text("✓ Healthy" if nsls2_health else "✗ Unhealthy", 
-                         style="health.good" if nsls2_health else "health.bad")
+                    Text(
+                        "✓ Healthy" if nsls2_health else "✗ Unhealthy",
+                        style="health.good" if nsls2_health else "health.bad",
+                    ),
                 )
                 health_table.add_row(
                     "LBMS",
-                    Text("✓ Healthy" if lbms_health else "✗ Unhealthy", 
-                         style="health.good" if lbms_health else "health.bad")
+                    Text(
+                        "✓ Healthy" if lbms_health else "✗ Unhealthy",
+                        style="health.good" if lbms_health else "health.bad",
+                    ),
                 )
 
                 # Create NSLS-II proposals per cycle table
@@ -121,8 +136,7 @@ def metrics():
 
                 for cycle_data in stats_data["nsls2_proposals_per_cycle"]:
                     nsls2_table.add_row(
-                        cycle_data["cycle"],
-                        str(cycle_data["proposal_count"])
+                        cycle_data["cycle"], str(cycle_data["proposal_count"])
                     )
 
                 # Create LBMS proposals per cycle table
@@ -132,15 +146,12 @@ def metrics():
 
                 for cycle_data in stats_data["lbms_proposals_per_cycle"]:
                     lbms_table.add_row(
-                        cycle_data["cycle"],
-                        str(cycle_data["proposal_count"])
+                        cycle_data["cycle"], str(cycle_data["proposal_count"])
                     )
 
                 # Create main panel
                 main_panel = Panel(
-                    metrics_table,
-                    title="NSLS-II API Metrics",
-                    border_style="green"
+                    metrics_table, title="NSLS-II API Metrics", border_style="green"
                 )
 
                 # Print all panels and tables
@@ -153,13 +164,13 @@ def metrics():
             panel = Panel(
                 f"[error]HTTP Error: {exc.response.status_code} - {exc.response.reason_phrase}",
                 title="API Metrics Error",
-                border_style="red"
+                border_style="red",
             )
             console.print(panel)
         except httpx.RequestError as exc:
             panel = Panel(
                 f"[error]Request Error: {exc}",
                 title="API Metrics Error",
-                border_style="red"
+                border_style="red",
             )
             console.print(panel)

--- a/src/nsls2api/cli/api.py
+++ b/src/nsls2api/cli/api.py
@@ -8,14 +8,15 @@ from rich.text import Text
 from rich.theme import Theme
 
 from nsls2api.cli.settings import get_base_url, get_token
+from nsls2api.cli.utils.cli_helpers import print_help_if_no_command
 
 app = typer.Typer(invoke_without_command=True)
 
+
 @app.callback()
-def users_callback(ctx: typer.Context):
-    if ctx.invoked_subcommand is None:
-        typer.echo(ctx.command.get_help(ctx))
-        raise typer.Exit()
+def main(ctx: typer.Context):
+    print_help_if_no_command(ctx)
+
 
 console = Console(
     theme=Theme(

--- a/src/nsls2api/cli/api.py
+++ b/src/nsls2api/cli/api.py
@@ -8,14 +8,15 @@ from rich.text import Text
 from rich.theme import Theme
 
 from nsls2api.cli.settings import get_base_url, get_token
-from nsls2api.cli.utils.cli_helpers import print_help_if_no_command
+from nsls2api.cli.utils.cli_helpers import auto_help_if_no_command
 
 app = typer.Typer(invoke_without_command=True)
 
 
 @app.callback()
-def main(ctx: typer.Context):
-    print_help_if_no_command(ctx)
+@auto_help_if_no_command()
+def api_callback(ctx: typer.Context):
+    pass  # No need to call anything manually
 
 
 console = Console(

--- a/src/nsls2api/cli/api.py
+++ b/src/nsls2api/cli/api.py
@@ -9,7 +9,14 @@ from rich.theme import Theme
 
 from nsls2api.cli.settings import get_base_url, get_token
 
-app = typer.Typer()
+app = typer.Typer(invoke_without_command=True)
+
+@app.callback()
+def users_callback(ctx: typer.Context):
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.command.get_help(ctx))
+        raise typer.Exit()
+
 console = Console(
     theme=Theme(
         {

--- a/src/nsls2api/cli/api.py
+++ b/src/nsls2api/cli/api.py
@@ -1,14 +1,13 @@
-import httpx
 import typer
 from rich.box import ROUNDED
-from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
-from rich.theme import Theme
 
-from nsls2api.cli.settings import get_base_url, get_token
+from nsls2api.cli.settings import get_base_url
+from nsls2api.cli.utils.api import call_nsls2api_endpoint
 from nsls2api.cli.utils.cli_helpers import auto_help_if_no_command
+from nsls2api.cli.utils.console import console
 
 app = typer.Typer(invoke_without_command=True)
 
@@ -19,167 +18,121 @@ def api_callback(ctx: typer.Context):
     pass  # No need to call anything manually
 
 
-console = Console(
-    theme=Theme(
-        {
-            "info": "cyan",
-            "warning": "yellow",
-            "error": "red bold",
-            "success": "green bold",
-            "health.good": "green bold",
-            "health.bad": "red bold",
-        }
-    )
-)
-
-
 @app.command()
 def status():
-    """Show general status of NSLS-II API"""
-    url = f"{get_base_url()}/v1/about"
+    """Show the general status of NSLS-II API"""
 
-    with console.status("[cyan]Fetching API status...", spinner="dots"):
-        try:
-            with httpx.Client() as client:
-                token = get_token()
-                headers = {"Authorization": f"{token}"} if token else {}
-                response = client.get(url, headers=headers)
-                response.raise_for_status()
-                about_data = response.json()
+    with console.status("[info]Fetching API status...", spinner="dots"):
+        endpoint = "v1/about"
+        response = call_nsls2api_endpoint(endpoint, method="GET")
 
-                # Create status table
-                status_table = Table(show_header=False, box=None)
-                status_table.add_column("Key", style="cyan")
-                status_table.add_column("Value", style="green")
-
-                status_table.add_row("Status", "✓ Available")
-                status_table.add_row("Version", about_data["version"])
-                status_table.add_row("Description", about_data["description"])
-                status_table.add_row("API URL", get_base_url())
-
-                # Add container info if available
-                if about_data.get("container_info"):
-                    status_table.add_row("Container", about_data["container_info"])
-
-                panel = Panel(
-                    status_table, title="NSLS-II API Status", border_style="green"
-                )
-                console.print(panel)
-
-        except httpx.HTTPStatusError as exc:
+        if response is None:
             panel = Panel(
-                f"[error]HTTP Error: {exc.response.status_code} - {exc.response.reason_phrase}",
+                "[error]Failed to retrieve API status. Please check your connection or API endpoint.[/error]",
                 title="API Status Error",
                 border_style="red",
             )
             console.print(panel)
-        except httpx.RequestError as exc:
-            panel = Panel(
-                f"[error]Request Error: {exc}",
-                title="API Status Error",
-                border_style="red",
-            )
-            console.print(panel)
+            raise typer.Exit(code=1)
+
+        about_data = response.json()
+
+        # Create a status table
+        status_table = Table(show_header=False, box=None)
+        status_table.add_column("Key", style="cyan")
+        status_table.add_column("Value", style="green")
+
+        status_table.add_row("Status", "✓ Available")
+        status_table.add_row("Version", about_data["version"])
+        status_table.add_row("Description", about_data["description"])
+        status_table.add_row("API URL", get_base_url())
+
+        # Add container info if available
+        if about_data.get("container_info"):
+            status_table.add_row("Container", about_data["container_info"])
+
+        panel = Panel(status_table, title="NSLS-II API Status", border_style="green")
+        console.print(panel)
 
 
 @app.command()
 def metrics():
     """Show general metrics of NSLS-II API"""
-    url = f"{get_base_url()}/v1/stats"
 
-    with console.status("[cyan]Fetching API metrics...", spinner="dots"):
-        try:
-            with httpx.Client() as client:
-                token = get_token()
-                headers = {"Authorization": f"{token}"} if token else {}
-                response = client.get(url, headers=headers)
-                response.raise_for_status()
-                stats_data = response.json()
+    with console.status("[info]Fetching API metrics...", spinner="dots"):
+        endpoint = "v1/stats"
+        response = call_nsls2api_endpoint(endpoint, method="GET")
 
-                # Create main metrics table
-                metrics_table = Table(show_header=False, box=None)
-                metrics_table.add_column("Key", style="cyan")
-                metrics_table.add_column("Value", style="green")
-
-                metrics_table.add_row(
-                    "Facility Count", str(stats_data["facility_count"])
-                )
-                metrics_table.add_row(
-                    "Beamline Count", str(stats_data["beamline_count"])
-                )
-                metrics_table.add_row(
-                    "Proposal Count", str(stats_data["proposal_count"])
-                )
-                metrics_table.add_row(
-                    "Commissioning Proposal Count",
-                    str(stats_data["commissioning_proposal_count"]),
-                )
-
-                # Create health status table
-                health_table = Table(title="Data Health Status", box=ROUNDED)
-                health_table.add_column("Facility", style="cyan")
-                health_table.add_column("Status", style="green")
-
-                nsls2_health = stats_data["nsls2_data_health"]
-                lbms_health = stats_data["lbms_data_health"]
-
-                health_table.add_row(
-                    "NSLS-II",
-                    Text(
-                        "✓ Healthy" if nsls2_health else "✗ Unhealthy",
-                        style="health.good" if nsls2_health else "health.bad",
-                    ),
-                )
-                health_table.add_row(
-                    "LBMS",
-                    Text(
-                        "✓ Healthy" if lbms_health else "✗ Unhealthy",
-                        style="health.good" if lbms_health else "health.bad",
-                    ),
-                )
-
-                # Create NSLS-II proposals per cycle table
-                nsls2_table = Table(title="NSLS-II Proposals Per Cycle", box=ROUNDED)
-                nsls2_table.add_column("Cycle", style="cyan")
-                nsls2_table.add_column("Proposal Count", style="green", justify="right")
-
-                for cycle_data in stats_data["nsls2_proposals_per_cycle"]:
-                    nsls2_table.add_row(
-                        cycle_data["cycle"], str(cycle_data["proposal_count"])
-                    )
-
-                # Create LBMS proposals per cycle table
-                lbms_table = Table(title="LBMS Proposals Per Cycle", box=ROUNDED)
-                lbms_table.add_column("Cycle", style="cyan")
-                lbms_table.add_column("Proposal Count", style="green", justify="right")
-
-                for cycle_data in stats_data["lbms_proposals_per_cycle"]:
-                    lbms_table.add_row(
-                        cycle_data["cycle"], str(cycle_data["proposal_count"])
-                    )
-
-                # Create main panel
-                main_panel = Panel(
-                    metrics_table, title="NSLS-II API Metrics", border_style="green"
-                )
-
-                # Print all panels and tables
-                console.print(main_panel)
-                console.print(health_table)
-                console.print(nsls2_table)
-                console.print(lbms_table)
-
-        except httpx.HTTPStatusError as exc:
+        if response is None:
             panel = Panel(
-                f"[error]HTTP Error: {exc.response.status_code} - {exc.response.reason_phrase}",
+                "[error]Failed to retrieve API metrics. Please check your connection or API endpoint.[/error]",
                 title="API Metrics Error",
                 border_style="red",
             )
             console.print(panel)
-        except httpx.RequestError as exc:
-            panel = Panel(
-                f"[error]Request Error: {exc}",
-                title="API Metrics Error",
-                border_style="red",
-            )
-            console.print(panel)
+            raise typer.Exit(code=1)
+
+        stats_data = response.json()
+
+        # Create main metrics table
+        metrics_table = Table(show_header=False, box=None)
+        metrics_table.add_column("Key", style="cyan")
+        metrics_table.add_column("Value", style="green")
+
+        metrics_table.add_row("Facility Count", str(stats_data["facility_count"]))
+        metrics_table.add_row("Beamline Count", str(stats_data["beamline_count"]))
+        metrics_table.add_row("Proposal Count", str(stats_data["proposal_count"]))
+        metrics_table.add_row(
+            "Commissioning Proposal Count",
+            str(stats_data["commissioning_proposal_count"]),
+        )
+
+        # Create a health status table
+        health_table = Table(title="Data Health Status", box=ROUNDED)
+        health_table.add_column("Facility", style="cyan")
+        health_table.add_column("Status", style="green")
+
+        nsls2_health = stats_data["nsls2_data_health"]
+        lbms_health = stats_data["lbms_data_health"]
+
+        health_table.add_row(
+            "NSLS-II",
+            Text(
+                "✓ Healthy" if nsls2_health else "✗ Unhealthy",
+                style="health.good" if nsls2_health else "health.bad",
+            ),
+        )
+        health_table.add_row(
+            "LBMS",
+            Text(
+                "✓ Healthy" if lbms_health else "✗ Unhealthy",
+                style="health.good" if lbms_health else "health.bad",
+            ),
+        )
+
+        # Create NSLS-II proposals per cycle table
+        nsls2_table = Table(title="NSLS-II Proposals Per Cycle", box=ROUNDED)
+        nsls2_table.add_column("Cycle", style="cyan")
+        nsls2_table.add_column("Proposal Count", style="green", justify="right")
+
+        for cycle_data in stats_data["nsls2_proposals_per_cycle"]:
+            nsls2_table.add_row(cycle_data["cycle"], str(cycle_data["proposal_count"]))
+
+        # Create LBMS proposals per cycle table
+        lbms_table = Table(title="LBMS Proposals Per Cycle", box=ROUNDED)
+        lbms_table.add_column("Cycle", style="cyan")
+        lbms_table.add_column("Proposal Count", style="green", justify="right")
+
+        for cycle_data in stats_data["lbms_proposals_per_cycle"]:
+            lbms_table.add_row(cycle_data["cycle"], str(cycle_data["proposal_count"]))
+
+        # Create the main panel
+        main_panel = Panel(
+            metrics_table, title="NSLS-II API Metrics", border_style="green"
+        )
+
+        # Print all panels and tables
+        console.print(main_panel)
+        console.print(health_table)
+        console.print(nsls2_table)
+        console.print(lbms_table)

--- a/src/nsls2api/cli/api.py
+++ b/src/nsls2api/cli/api.py
@@ -58,7 +58,7 @@ def status():
                 status_table.add_row("API URL", get_base_url())
 
                 # Add container info if available
-                if "container_info" in about_data and about_data["container_info"]:
+                if about_data.get("container_info"):
                     status_table.add_row("Container", about_data["container_info"])
 
                 panel = Panel(

--- a/src/nsls2api/cli/auth.py
+++ b/src/nsls2api/cli/auth.py
@@ -1,24 +1,27 @@
 import getpass
+from typing import Optional, Tuple
+
 import httpx
 import typer
-from typing import Optional, Tuple
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
-from rich.text import Text
-from rich.style import Style
 from rich.theme import Theme
 
-from nsls2api.cli.settings import get_base_url, get_token, set_token, remove_token
-from nsls2api.infrastructure.security import SpecialUsers
+from nsls2api.cli.settings import get_base_url, get_token, remove_token, set_token
 
 app = typer.Typer()
-console = Console(theme=Theme({
-    "info": "cyan",
-    "warning": "yellow",
-    "error": "red bold",
-    "success": "green bold"
-}))
+console = Console(
+    theme=Theme(
+        {
+            "info": "cyan",
+            "warning": "yellow",
+            "error": "red bold",
+            "success": "green bold",
+        }
+    )
+)
+
 
 def verify_token(token: str) -> Tuple[bool, Optional[str]]:
     """
@@ -42,98 +45,98 @@ def verify_token(token: str) -> Tuple[bool, Optional[str]]:
     except httpx.RequestError as exc:
         return False, f"An error occurred while trying to contact the API: {exc}"
 
+
 def create_status_table(username: str, api_url: str) -> Table:
     """Create a rich table for status display"""
     table = Table(show_header=False, box=None)
     table.add_column("Key", style="cyan")
     table.add_column("Value", style="green")
-    
+
     table.add_row("Status", "✓ Authenticated")
     table.add_row("Username", username)
     table.add_row("API URL", api_url)
     return table
+
 
 @app.command()
 def status():
     """Show the current authentication status"""
     with console.status("[cyan]Checking authentication status...", spinner="dots"):
         token = get_token()
-        
+
         if token is None:
             panel = Panel(
                 "[warning]Not currently logged in\n[info]Use [bold]nsls2api auth login[/bold] to authenticate",
                 title="Authentication Status",
-                border_style="yellow"
+                border_style="yellow",
             )
             console.print(panel)
             return
 
         is_valid, result = verify_token(token)
-        
+
         if is_valid:
             table = create_status_table(result, get_base_url())
-            panel = Panel(
-                table,
-                title="Authentication Status",
-                border_style="green"
-            )
+            panel = Panel(table, title="Authentication Status", border_style="green")
             console.print(panel)
         else:
             panel = Panel(
                 f"[error]{result}\n[info]Use [bold]nsls2api auth login[/bold] to reauthenticate",
                 title="Authentication Error",
-                border_style="red"
+                border_style="red",
             )
             console.print(panel)
+
 
 @app.command()
 def login():
     """Log in to the NSLS-II API"""
     token = get_token()
     read_token_from_file = True
-    
+
     if token is None:
         read_token_from_file = False
         console.print("[info]No API token found")
         token = getpass.getpass(prompt="Please enter your API token: ")
         if len(token) == 0:
-            logged_in_username: SpecialUsers = SpecialUsers.anonymous
+            # logged_in_username: SpecialUsers = SpecialUsers.anonymous
             console.print("[warning]Authenticated as anonymous")
             return
 
     with console.status("[cyan]Verifying credentials...", spinner="dots"):
         is_valid, result = verify_token(token)
-        
+
     if is_valid:
         if not read_token_from_file:
             set_token(token)
-            console.print(Panel(
-                f"[success]Successfully authenticated as {result}\n[info]Token saved to config file",
-                title="Login Successful",
-                border_style="green"
-            ))
+            console.print(
+                Panel(
+                    f"[success]Successfully authenticated as {result}\n[info]Token saved to config file",
+                    title="Login Successful",
+                    border_style="green",
+                )
+            )
         else:
-            console.print(Panel(
-                f"[success]Successfully authenticated as {result}",
-                title="Login Successful",
-                border_style="green"
-            ))
+            console.print(
+                Panel(
+                    f"[success]Successfully authenticated as {result}",
+                    title="Login Successful",
+                    border_style="green",
+                )
+            )
     else:
-        console.print(Panel(
-            f"[error]{result}",
-            title="Login Failed",
-            border_style="red"
-        ))
+        console.print(
+            Panel(f"[error]{result}", title="Login Failed", border_style="red")
+        )
+
 
 @app.command()
 def logout():
     """Log out and remove stored credentials"""
     with console.status("[cyan]Logging out...", spinner="dots"):
         remove_token()
-    
+
     panel = Panel(
-        "[success]Successfully logged out",
-        title="Logout",
-        border_style="green"
+        "[success]Successfully logged out", title="Logout", border_style="green"
     )
     console.print(panel)

--- a/src/nsls2api/cli/auth.py
+++ b/src/nsls2api/cli/auth.py
@@ -1,59 +1,78 @@
-import configparser
 import getpass
-import os
-from configparser import NoOptionError, NoSectionError
-from pathlib import Path
-from typing import Optional
-
 import httpx
 import typer
+from typing import Optional, Tuple
 
+from nsls2api.cli.settings import get_base_url, get_token, set_token, remove_token
 from nsls2api.infrastructure.security import SpecialUsers
-
-BASE_URL = "http://localhost:8000"
 
 app = typer.Typer()
 
-
-def config_from_file() -> Optional[str]:
-    config = configparser.ConfigParser()
-    config_userhome = os.path.expanduser("~")
-    config_filepath = Path(config_userhome) / ".config" / "nsls2"
-    print(f"Reading config from {config_filepath}")
-
-    try:
-        config.read(config_filepath)
-        api_client_token = config.get("api", "token")
-    except (NoSectionError, NoOptionError):
-        # If there is no config we are just going to login as Anonymous
-        # so no need to raise an error.
-        return None
-
-    return api_client_token
-
-
-@app.command()
-def status():
-    # Let's see if there is a token in the local config file ?
-    token = config_from_file()
-    if token is None:
-        print("No API token found")
-        token = getpass.getpass(prompt="Please enter your API token:")
-        if len(token) == 0:
-            logged_in_username: SpecialUsers = SpecialUsers.anonymous
-            print("Authenticated as anonymous")
-            return
-
-    # Let's test this token
-    url = f"{BASE_URL}/v1/person/me"
+def verify_token(token: str) -> Tuple[bool, Optional[str]]:
+    """
+    Verify if a token is valid by making an API call.
+    Returns a tuple of (is_valid, username or error_message)
+    """
+    url = f"{get_base_url()}/v1/person/me"
     try:
         with httpx.Client() as client:
             headers = {"Authorization": f"{token}"}
             response = client.get(url, headers=headers)
             response.raise_for_status()
-            logged_in_username = response.json()
+            return True, response.json()
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 401:
+            return False, "Invalid API token"
+        elif exc.response.status_code == 403:
+            return False, "Access denied"
+        else:
+            return False, f"An error occurred: {exc}"
     except httpx.RequestError as exc:
-        print(f"An error occurred while trying to login {exc}")
-        raise
+        return False, f"An error occurred while trying to contact the API: {exc}"
 
-    print(f"Authenticated as {logged_in_username}")
+@app.command()
+def status():
+    """Show the current authentication status"""
+    token = get_token()
+    if token is None:
+        typer.echo("Not logged in. Use 'nsls2api auth login' to authenticate.")
+        return
+
+    is_valid, result = verify_token(token)
+    if is_valid:
+        typer.echo(f"Logged in as: {result}")
+        typer.echo(f"API URL: {get_base_url()}")
+    else:
+        typer.echo(f"Authentication error: {result}")
+        typer.echo("Use 'nsls2api auth login' to reauthenticate.")
+
+@app.command()
+def login():
+    """Log in to the NSLS-II API"""
+    # Let's see if there is a token in the local config file
+    token = get_token()
+    read_token_from_file = True
+    
+    if token is None:
+        read_token_from_file = False
+        typer.echo("No API token found")
+        token = getpass.getpass(prompt="Please enter your API token:")
+        if len(token) == 0:
+            logged_in_username: SpecialUsers = SpecialUsers.anonymous
+            typer.echo("Authenticated as anonymous")
+            return
+
+    is_valid, result = verify_token(token)
+    if is_valid:
+        typer.echo(f"Authenticated as {result}")
+        if not read_token_from_file:
+            set_token(token)
+            typer.echo("Token saved to config file")
+    else:
+        typer.echo(result)
+
+@app.command()
+def logout():
+    """Log out and remove stored credentials"""
+    remove_token()
+    typer.echo("Logged out successfully")

--- a/src/nsls2api/cli/auth.py
+++ b/src/nsls2api/cli/auth.py
@@ -2,11 +2,23 @@ import getpass
 import httpx
 import typer
 from typing import Optional, Tuple
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+from rich.style import Style
+from rich.theme import Theme
 
 from nsls2api.cli.settings import get_base_url, get_token, set_token, remove_token
 from nsls2api.infrastructure.security import SpecialUsers
 
 app = typer.Typer()
+console = Console(theme=Theme({
+    "info": "cyan",
+    "warning": "yellow",
+    "error": "red bold",
+    "success": "green bold"
+}))
 
 def verify_token(token: str) -> Tuple[bool, Optional[str]]:
     """
@@ -30,49 +42,98 @@ def verify_token(token: str) -> Tuple[bool, Optional[str]]:
     except httpx.RequestError as exc:
         return False, f"An error occurred while trying to contact the API: {exc}"
 
+def create_status_table(username: str, api_url: str) -> Table:
+    """Create a rich table for status display"""
+    table = Table(show_header=False, box=None)
+    table.add_column("Key", style="cyan")
+    table.add_column("Value", style="green")
+    
+    table.add_row("Status", "✓ Authenticated")
+    table.add_row("Username", username)
+    table.add_row("API URL", api_url)
+    return table
+
 @app.command()
 def status():
     """Show the current authentication status"""
-    token = get_token()
-    if token is None:
-        typer.echo("Not logged in. Use 'nsls2api auth login' to authenticate.")
-        return
+    with console.status("[cyan]Checking authentication status...", spinner="dots"):
+        token = get_token()
+        
+        if token is None:
+            panel = Panel(
+                "[warning]Not currently logged in\n[info]Use [bold]nsls2api auth login[/bold] to authenticate",
+                title="Authentication Status",
+                border_style="yellow"
+            )
+            console.print(panel)
+            return
 
-    is_valid, result = verify_token(token)
-    if is_valid:
-        typer.echo(f"Logged in as: {result}")
-        typer.echo(f"API URL: {get_base_url()}")
-    else:
-        typer.echo(f"Authentication error: {result}")
-        typer.echo("Use 'nsls2api auth login' to reauthenticate.")
+        is_valid, result = verify_token(token)
+        
+        if is_valid:
+            table = create_status_table(result, get_base_url())
+            panel = Panel(
+                table,
+                title="Authentication Status",
+                border_style="green"
+            )
+            console.print(panel)
+        else:
+            panel = Panel(
+                f"[error]{result}\n[info]Use [bold]nsls2api auth login[/bold] to reauthenticate",
+                title="Authentication Error",
+                border_style="red"
+            )
+            console.print(panel)
 
 @app.command()
 def login():
     """Log in to the NSLS-II API"""
-    # Let's see if there is a token in the local config file
     token = get_token()
     read_token_from_file = True
     
     if token is None:
         read_token_from_file = False
-        typer.echo("No API token found")
-        token = getpass.getpass(prompt="Please enter your API token:")
+        console.print("[info]No API token found")
+        token = getpass.getpass(prompt="Please enter your API token: ")
         if len(token) == 0:
             logged_in_username: SpecialUsers = SpecialUsers.anonymous
-            typer.echo("Authenticated as anonymous")
+            console.print("[warning]Authenticated as anonymous")
             return
 
-    is_valid, result = verify_token(token)
+    with console.status("[cyan]Verifying credentials...", spinner="dots"):
+        is_valid, result = verify_token(token)
+        
     if is_valid:
-        typer.echo(f"Authenticated as {result}")
         if not read_token_from_file:
             set_token(token)
-            typer.echo("Token saved to config file")
+            console.print(Panel(
+                f"[success]Successfully authenticated as {result}\n[info]Token saved to config file",
+                title="Login Successful",
+                border_style="green"
+            ))
+        else:
+            console.print(Panel(
+                f"[success]Successfully authenticated as {result}",
+                title="Login Successful",
+                border_style="green"
+            ))
     else:
-        typer.echo(result)
+        console.print(Panel(
+            f"[error]{result}",
+            title="Login Failed",
+            border_style="red"
+        ))
 
 @app.command()
 def logout():
     """Log out and remove stored credentials"""
-    remove_token()
-    typer.echo("Logged out successfully")
+    with console.status("[cyan]Logging out...", spinner="dots"):
+        remove_token()
+    
+    panel = Panel(
+        "[success]Successfully logged out",
+        title="Logout",
+        border_style="green"
+    )
+    console.print(panel)

--- a/src/nsls2api/cli/auth.py
+++ b/src/nsls2api/cli/auth.py
@@ -3,21 +3,20 @@ from typing import Optional, Tuple
 
 import httpx
 import typer
-from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
-from rich.theme import Theme
 
 from nsls2api.cli.settings import get_base_url, get_token, remove_token, set_token
+from nsls2api.cli.utils.cli_helpers import print_help_if_no_command
 from nsls2api.cli.utils.console import console
 
 app = typer.Typer(invoke_without_command=True)
 
+
 @app.callback()
-def users_callback(ctx: typer.Context):
-    if ctx.invoked_subcommand is None:
-        typer.echo(ctx.command.get_help(ctx))
-        raise typer.Exit()
+def main(ctx: typer.Context):
+    print_help_if_no_command(ctx)
+
 
 def verify_token(token: str) -> Tuple[bool, Optional[str]]:
     """

--- a/src/nsls2api/cli/auth.py
+++ b/src/nsls2api/cli/auth.py
@@ -9,19 +9,15 @@ from rich.table import Table
 from rich.theme import Theme
 
 from nsls2api.cli.settings import get_base_url, get_token, remove_token, set_token
+from nsls2api.cli.utils.console import console
 
-app = typer.Typer()
-console = Console(
-    theme=Theme(
-        {
-            "info": "cyan",
-            "warning": "yellow",
-            "error": "red bold",
-            "success": "green bold",
-        }
-    )
-)
+app = typer.Typer(invoke_without_command=True)
 
+@app.callback()
+def users_callback(ctx: typer.Context):
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.command.get_help(ctx))
+        raise typer.Exit()
 
 def verify_token(token: str) -> Tuple[bool, Optional[str]]:
     """

--- a/src/nsls2api/cli/auth.py
+++ b/src/nsls2api/cli/auth.py
@@ -7,15 +7,16 @@ from rich.panel import Panel
 from rich.table import Table
 
 from nsls2api.cli.settings import get_base_url, get_token, remove_token, set_token
-from nsls2api.cli.utils.cli_helpers import print_help_if_no_command
+from nsls2api.cli.utils.cli_helpers import auto_help_if_no_command
 from nsls2api.cli.utils.console import console
 
 app = typer.Typer(invoke_without_command=True)
 
 
 @app.callback()
-def main(ctx: typer.Context):
-    print_help_if_no_command(ctx)
+@auto_help_if_no_command()
+def auth_callback(ctx: typer.Context):
+    pass  # No need to call anything manually
 
 
 def verify_token(token: str) -> Tuple[bool, Optional[str]]:

--- a/src/nsls2api/cli/beamline.py
+++ b/src/nsls2api/cli/beamline.py
@@ -5,8 +5,13 @@ from rich.table import Table
 from nsls2api.cli.utils.api import call_nsls2api_endpoint
 from nsls2api.cli.utils.console import console, error
 
-app = typer.Typer()
+app = typer.Typer(invoke_without_command=True)
 
+@app.callback()
+def users_callback(ctx: typer.Context):
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.command.get_help(ctx))
+        raise typer.Exit()
 
 @app.command("list")
 def list_beamlines():

--- a/src/nsls2api/cli/beamline.py
+++ b/src/nsls2api/cli/beamline.py
@@ -3,15 +3,16 @@ from rich.panel import Panel
 from rich.table import Table
 
 from nsls2api.cli.utils.api import call_nsls2api_endpoint
+from nsls2api.cli.utils.cli_helpers import print_help_if_no_command
 from nsls2api.cli.utils.console import console, error
 
 app = typer.Typer(invoke_without_command=True)
 
+
 @app.callback()
-def users_callback(ctx: typer.Context):
-    if ctx.invoked_subcommand is None:
-        typer.echo(ctx.command.get_help(ctx))
-        raise typer.Exit()
+def main(ctx: typer.Context):
+    print_help_if_no_command(ctx)
+
 
 @app.command("list")
 def list_beamlines():

--- a/src/nsls2api/cli/beamline.py
+++ b/src/nsls2api/cli/beamline.py
@@ -1,7 +1,20 @@
 import typer
+import requests
+
+from rich.console import Console
+from rich.table import Table
+from rich.theme import Theme
+from rich.panel import Panel
+
+from nsls2api.cli.settings import get_base_url, get_token, set_token, remove_token
 
 app = typer.Typer()
-
+console = Console(theme=Theme({
+    "info": "cyan",
+    "warning": "yellow",
+    "error": "red bold",
+    "success": "green bold"
+}))
 
 @app.command()
 def view(beamline: str):
@@ -10,4 +23,76 @@ def view(beamline: str):
 
 @app.command("list")
 def list_beamlines():
-    print("Listing beamlines...")
+    """
+    Retrieve and display a list of beamlines from the API.
+    """
+    try:
+        response = requests.get(f"{get_base_url()}/v1/beamlines")
+        response.raise_for_status()
+    except Exception as e:
+        console.print(f"[red]Error fetching beamlines: {e}[/red]")
+        raise typer.Exit(code=1)
+    # Expecting the API to return a list of beamlines
+    beamlines = response.json()
+    table = Table(title="Beamlines")
+    table.add_column("ID", style="cyan", no_wrap=True)
+    table.add_column("Name", style="magenta")
+    # Adjust row extraction based on API response structure
+    for beam in beamlines:
+        table.add_row(str(beam.get("port", "")), beam.get("name", ""), beam.get("long_name", ""))
+    console.print(table)
+
+@app.command("view")
+def view_beamline(beamline: str):
+    """
+    Retrieve and display details of a specific beamline.
+
+    Args:
+        beamline (str): The identifier of the beamline.
+    """
+    try:
+        response = requests.get(f"{get_base_url()}/v1/beamline/{beamline}")
+        response.raise_for_status()
+    except Exception as e:
+        console.print(f"[error]Error fetching beamline details: {e}[/error]")
+        raise typer.Exit(code=1)
+    details = response.json()
+    # Create a table with headers for fields and values
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Field", style="blue", no_wrap=True)
+    table.add_column("Value", style="white")
+    for key, value in details.items():
+        table.add_row(str(key), str(value))
+    # Wrap table in a panel for a nicer output
+    panel = Panel(table, title=f"Beamline Details: {beamline}", title_align="left")
+    console.print(panel)
+
+@app.command("detectors")
+def list_detectors(beamline: str):
+    """
+    Retrieve and display detectors for a specific beamline.
+
+    Args:
+        beamline (str): The identifier of the beamline.
+    """
+    try:
+        response = requests.get(f"{get_base_url()}/v1/beamline/{beamline}/detectors")
+        response.raise_for_status()
+    except Exception as e:
+        console.print(f"[error]Error fetching detectors: {e}[/error]")
+        raise typer.Exit(code=1)
+    detectors = response.json().get("detectors", [])
+    if not detectors:
+        console.print(f"[warning]No detectors found for beamline: {beamline}[/warning]")
+        return
+    table = Table(title=f"Detectors for Beamline: {beamline}")
+    table.add_column("Name", style="cyan")
+    table.add_column("Description", style="magenta")
+    table.add_column("Granularity", style="green")
+    for detector in detectors:
+        table.add_row(
+            detector.get("name", ""),
+            detector.get("description", "N/A"),
+            detector.get("granularity", "N/A"),
+        )
+    console.print(table)

--- a/src/nsls2api/cli/beamline.py
+++ b/src/nsls2api/cli/beamline.py
@@ -3,7 +3,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from nsls2api.cli.utils.api import call_nsls2api_endpoint
-from nsls2api.cli.utils.console import console
+from nsls2api.cli.utils.console import console, error
 
 app = typer.Typer()
 
@@ -18,7 +18,7 @@ def list_beamlines():
 
     # Expecting the API to return a list of beamlines
     if response is None:
-        console.print("[red]Failed to retrieve beamlines.[/red]")
+        error("ERROR: Failed to retrieve beamlines.")
         raise typer.Exit(code=1)
     beamlines = response.json()
     table = Table(title="Beamlines", show_header=True, header_style="bold green")

--- a/src/nsls2api/cli/beamline.py
+++ b/src/nsls2api/cli/beamline.py
@@ -1,6 +1,8 @@
+from typing import Optional
+
 import httpx
-import requests
 import typer
+from httpx import Response
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -21,31 +23,57 @@ console = Console(
 )
 
 
+def call_nsls2api_endpoint(
+    endpoint: str, method: str = "GET", data: dict = None
+) -> Optional[Response]:
+    """
+    Call the NSLS-II API endpoint and return the response.
+    """
+    url = f"{get_base_url()}/{endpoint}"
+    try:
+        with httpx.Client() as client:
+            token = get_token()
+            headers = {"Authorization": f"{token}"} if token else {}
+            if method == "GET":
+                response = client.get(url, headers=headers)
+            elif method == "POST":
+                response = client.post(url, json=data, headers=headers)
+            response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 401:
+            console.print("[red]Invalid API token[/red]")
+            return None
+        elif exc.response.status_code == 403:
+            console.print("[red]Access denied[/red]")
+            return None
+        elif exc.response.status_code == 404:
+            console.print(f"[red]Endpoint not found: {url}[/red]")
+            return None
+        else:
+            console.print(
+                f"[red]An error occurred while trying to contact the API: {exc}[/red]"
+            )
+            return None
+    except httpx.RequestError as exc:
+        console.print(
+            f"[red]An error occurred while trying to contact the API: {exc}[/red]"
+        )
+        return None
+    return response
+
+
 @app.command("list")
 def list_beamlines():
     """
     Retrieve and display a list of beamlines from the API.
     """
-    url = f"{get_base_url()}/v1/beamlines"
-    try:
-        with httpx.Client() as client:
-            token = get_token()
-            headers = {"Authorization": f"{token}"} if token else {}
-            response = client.get(url, headers=headers)
-            response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        if exc.response.status_code == 401:
-            return False, "Invalid API token"
-        elif exc.response.status_code == 403:
-            return False, "Access denied"
-        else:
-            return False, f"An error occurred: {exc}"
-    except httpx.RequestError as exc:
-        console.print(
-            f"[red]An error occurred while trying to contact the API: {exc}[/red]"
-        )
+    endpoint = "v1/beamlines"
+    response = call_nsls2api_endpoint(endpoint, method="GET")
 
     # Expecting the API to return a list of beamlines
+    if response is None:
+        console.print("[red]Failed to retrieve beamlines.[/red]")
+        raise typer.Exit(code=1)
     beamlines = response.json()
     table = Table(title="Beamlines", show_header=True, header_style="bold green")
     table.add_column("ID", style="cyan", no_wrap=True)
@@ -68,31 +96,12 @@ def view_beamline(beamline: str):
     Args:
         beamline (str): The identifier of the beamline.
     """
-    url = f"{get_base_url()}/v1/beamline/{beamline}"
-    try:
-        with httpx.Client() as client:
-            token = get_token()
-            headers = {"Authorization": f"{token}"} if token else {}
-            response = client.get(url, headers=headers)
-            response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        if exc.response.status_code == 401:
-            return False, "Invalid API token"
-        elif exc.response.status_code == 403:
-            return False, "Access denied"
-        else:
-            return False, f"An error occurred: {exc}"
-    except httpx.RequestError as exc:
-        console.print(
-            f"[red]An error occurred while trying to contact the API: {exc}[/red]"
-        )
-
-    try:
-        response = requests.get()
-        response.raise_for_status()
-    except Exception as e:
-        console.print(f"[error]Error fetching beamline details: {e}[/error]")
+    endpoint = f"v1/beamline/{beamline}"
+    response = call_nsls2api_endpoint(endpoint)
+    if response is None:
+        console.print(f"[red]Failed to retrieve details for {beamline} beamline.[/red]")
         raise typer.Exit(code=1)
+
     details = response.json()
     # Create a table with headers for fields and values
     table = Table(show_header=True, header_style="bold green")
@@ -113,24 +122,28 @@ def list_detectors(beamline: str):
     Args:
         beamline (str): The identifier of the beamline.
     """
-    try:
-        response = requests.get(f"{get_base_url()}/v1/beamline/{beamline}/detectors")
-        response.raise_for_status()
-    except Exception as e:
-        console.print(f"[error]Error fetching detectors: {e}[/error]")
+    endpoint = f"v1/beamline/{beamline}/detectors"
+    # Call the API to get the list of detectors
+    response = call_nsls2api_endpoint(endpoint)
+    if response is None:
+        console.print("[red]Failed to retrieve detectors.[/red]")
         raise typer.Exit(code=1)
     detectors = response.json().get("detectors", [])
     if not detectors:
         console.print(f"[warning]No detectors found for beamline: {beamline}[/warning]")
-        return
+        typer.Exit()
     table = Table(title=f"Detectors for Beamline: {beamline}")
     table.add_column("Name", style="cyan")
+    table.add_column("Manufacturer", style="blue")
     table.add_column("Description", style="magenta")
+    table.add_column("Directory", style="magenta")
     table.add_column("Granularity", style="green")
     for detector in detectors:
         table.add_row(
             detector.get("name", ""),
+            detector.get("manufacturer", ""),
             detector.get("description", "N/A"),
+            detector.get("directory_name", "N/A"),
             detector.get("granularity", "N/A"),
         )
     console.print(table)

--- a/src/nsls2api/cli/beamline.py
+++ b/src/nsls2api/cli/beamline.py
@@ -3,15 +3,16 @@ from rich.panel import Panel
 from rich.table import Table
 
 from nsls2api.cli.utils.api import call_nsls2api_endpoint
-from nsls2api.cli.utils.cli_helpers import print_help_if_no_command
+from nsls2api.cli.utils.cli_helpers import auto_help_if_no_command
 from nsls2api.cli.utils.console import console, error
 
 app = typer.Typer(invoke_without_command=True)
 
 
 @app.callback()
-def main(ctx: typer.Context):
-    print_help_if_no_command(ctx)
+@auto_help_if_no_command()
+def beamline_callback(ctx: typer.Context):
+    pass  # No need to call anything manually
 
 
 @app.command("list")

--- a/src/nsls2api/cli/beamline.py
+++ b/src/nsls2api/cli/beamline.py
@@ -84,7 +84,7 @@ def list_detectors(beamline: str):
     detectors = response.json().get("detectors", [])
     if not detectors:
         console.print(f"[warning]No detectors found for beamline: {beamline}[/warning]")
-        typer.Exit()
+        raise typer.Exit()
     table = Table(title=f"Detectors for Beamline: {beamline}")
     table.add_column("Name", style="cyan")
     table.add_column("Manufacturer", style="blue")

--- a/src/nsls2api/cli/beamline.py
+++ b/src/nsls2api/cli/beamline.py
@@ -1,24 +1,24 @@
-import typer
+import httpx
 import requests
-
+import typer
 from rich.console import Console
+from rich.panel import Panel
 from rich.table import Table
 from rich.theme import Theme
-from rich.panel import Panel
 
-from nsls2api.cli.settings import get_base_url, get_token, set_token, remove_token
+from nsls2api.cli.settings import get_base_url, get_token
 
 app = typer.Typer()
-console = Console(theme=Theme({
-    "info": "cyan",
-    "warning": "yellow",
-    "error": "red bold",
-    "success": "green bold"
-}))
-
-@app.command()
-def view(beamline: str):
-    print(f"Viewing Beamline : {beamline}")
+console = Console(
+    theme=Theme(
+        {
+            "info": "cyan",
+            "warning": "yellow",
+            "error": "red bold",
+            "success": "green bold",
+        }
+    )
+)
 
 
 @app.command("list")
@@ -26,21 +26,39 @@ def list_beamlines():
     """
     Retrieve and display a list of beamlines from the API.
     """
+    url = f"{get_base_url()}/v1/beamlines"
     try:
-        response = requests.get(f"{get_base_url()}/v1/beamlines")
-        response.raise_for_status()
-    except Exception as e:
-        console.print(f"[red]Error fetching beamlines: {e}[/red]")
-        raise typer.Exit(code=1)
+        with httpx.Client() as client:
+            token = get_token()
+            headers = {"Authorization": f"{token}"} if token else {}
+            response = client.get(url, headers=headers)
+            response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 401:
+            return False, "Invalid API token"
+        elif exc.response.status_code == 403:
+            return False, "Access denied"
+        else:
+            return False, f"An error occurred: {exc}"
+    except httpx.RequestError as exc:
+        console.print(
+            f"[red]An error occurred while trying to contact the API: {exc}[/red]"
+        )
+
     # Expecting the API to return a list of beamlines
     beamlines = response.json()
-    table = Table(title="Beamlines")
+    table = Table(title="Beamlines", show_header=True, header_style="bold green")
     table.add_column("ID", style="cyan", no_wrap=True)
     table.add_column("Name", style="magenta")
     # Adjust row extraction based on API response structure
     for beam in beamlines:
-        table.add_row(str(beam.get("port", "")), beam.get("name", ""), beam.get("long_name", ""))
-    console.print(table)
+        table.add_row(
+            str(beam.get("port", "")), beam.get("name", ""), beam.get("long_name", "")
+        )
+    # Wrap table in a panel for a nicer output
+    panel = Panel(table, title="All Beamlines", title_align="left")
+    console.print(panel)
+
 
 @app.command("view")
 def view_beamline(beamline: str):
@@ -50,15 +68,34 @@ def view_beamline(beamline: str):
     Args:
         beamline (str): The identifier of the beamline.
     """
+    url = f"{get_base_url()}/v1/beamline/{beamline}"
     try:
-        response = requests.get(f"{get_base_url()}/v1/beamline/{beamline}")
+        with httpx.Client() as client:
+            token = get_token()
+            headers = {"Authorization": f"{token}"} if token else {}
+            response = client.get(url, headers=headers)
+            response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 401:
+            return False, "Invalid API token"
+        elif exc.response.status_code == 403:
+            return False, "Access denied"
+        else:
+            return False, f"An error occurred: {exc}"
+    except httpx.RequestError as exc:
+        console.print(
+            f"[red]An error occurred while trying to contact the API: {exc}[/red]"
+        )
+
+    try:
+        response = requests.get()
         response.raise_for_status()
     except Exception as e:
         console.print(f"[error]Error fetching beamline details: {e}[/error]")
         raise typer.Exit(code=1)
     details = response.json()
     # Create a table with headers for fields and values
-    table = Table(show_header=True, header_style="bold magenta")
+    table = Table(show_header=True, header_style="bold green")
     table.add_column("Field", style="blue", no_wrap=True)
     table.add_column("Value", style="white")
     for key, value in details.items():
@@ -66,6 +103,7 @@ def view_beamline(beamline: str):
     # Wrap table in a panel for a nicer output
     panel = Panel(table, title=f"Beamline Details: {beamline}", title_align="left")
     console.print(panel)
+
 
 @app.command("detectors")
 def list_detectors(beamline: str):

--- a/src/nsls2api/cli/cli.py
+++ b/src/nsls2api/cli/cli.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import typer
 
-from nsls2api.cli import admin, api, auth, beamline, facility, proposal
+from nsls2api.cli import admin, api, auth, beamline, facility, proposal, environment
 
 __app_name__ = "nsls2api-cli"
 __version__ = "0.1.0"
@@ -14,6 +14,9 @@ app.add_typer(auth.app, name="auth", help="Stuff about security and fun")
 app.add_typer(beamline.app, name="beamline", help="Stuff about Beamlines")
 app.add_typer(facility.app, name="facility", help="Stuff about Facilities")
 app.add_typer(proposal.app, name="proposal", help="Stuff about Proposals")
+
+# Add the new environment management commands
+app.add_typer(environment.app, name="env")
 
 
 def _version_callback(value: bool) -> None:

--- a/src/nsls2api/cli/cli.py
+++ b/src/nsls2api/cli/cli.py
@@ -1,29 +1,18 @@
 import sys
-import typer
 from typing import Optional
-from rich.console import Console
-from rich.table import Table
-from rich.panel import Panel
+
+import typer
+from rich import box
 from rich.columns import Columns
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
 from rich.text import Text
 from rich.theme import Theme
-from rich.box import ROUNDED
-from rich import box
 
-from nsls2api.cli import (
-    admin,
-    api,
-    auth,
-    beamline,
-    environment,
-    facility,
-    proposal
-)
+from nsls2api.cli import admin, api, auth, beamline, environment, facility, proposal
 
-app = typer.Typer(
-    help="NSLS-II API Command Line Interface",
-    no_args_is_help=True
-)
+app = typer.Typer(help="NSLS-II API Command Line Interface", no_args_is_help=True)
 
 # Register sub-commands
 app.add_typer(admin.app, name="admin", help="Administrative commands")
@@ -34,37 +23,44 @@ app.add_typer(environment.app, name="env", help="Environment management")
 app.add_typer(facility.app, name="facility", help="Facility operations")
 app.add_typer(proposal.app, name="proposal", help="Proposal management")
 
-console = Console(theme=Theme({
-    "info": "cyan",
-    "warning": "yellow",
-    "error": "red bold",
-    "success": "green bold",
-    "command": "magenta bold",
-    "subcommand": "cyan",
-    "description": "white",
-    "heading": "yellow bold",
-}))
+console = Console(
+    theme=Theme(
+        {
+            "info": "cyan",
+            "warning": "yellow",
+            "error": "red bold",
+            "success": "green bold",
+            "command": "magenta bold",
+            "subcommand": "cyan",
+            "description": "white",
+            "heading": "yellow bold",
+        }
+    )
+)
+
 
 def create_command_panel(command_name: str, commands: dict) -> Panel:
     """Create a panel for a command group"""
     table = Table(show_header=False, box=None, padding=(0, 2))
     table.add_column("Command", style="subcommand")
     table.add_column("Description", style="description")
-    
+
     for cmd, desc in commands.items():
         table.add_row(cmd, desc)
-    
+
     return Panel(
         table,
         title=f"[heading]{command_name} Commands",
         border_style="blue",
-        box=box.ROUNDED
+        box=box.ROUNDED,
     )
+
 
 def show_welcome():
     """Display welcome message and version information"""
     try:
         from nsls2api._version import version
+
         version_str = version
     except ImportError:
         version_str = "unknown"
@@ -73,9 +69,10 @@ def show_welcome():
         Text("Welcome to the NSLS-II API Command Line Interface", style="info"),
         subtitle=f"Version: {version_str}",
         border_style="cyan",
-        box=box.DOUBLE
+        box=box.DOUBLE,
     )
     console.print(welcome_panel)
+
 
 def show_available_commands():
     """Display available commands in an organized layout"""
@@ -83,24 +80,19 @@ def show_available_commands():
         "Authentication": {
             "auth login": "Log in to the NSLS-II API",
             "auth logout": "Log out and remove stored credentials",
-            "auth status": "Show current authentication status"
+            "auth status": "Show current authentication status",
         },
         "Environment": {
             "env show": "Show current API environment",
-            "env switch": "Switch between environments (prod/dev/local)"
+            "env switch": "Switch between environments (prod/dev/local)",
         },
-        "API": {
-            "api status": "Show API status",
-            "api metrics": "Show API metrics"
-        },
+        "API": {"api status": "Show API status", "api metrics": "Show API metrics"},
         "Resources": {
             "beamline": "Manage beamline operations",
             "facility": "Manage facility operations",
-            "proposal": "Manage proposals"
+            "proposal": "Manage proposals",
         },
-        "Administration": {
-            "admin": "Administrative commands"
-        }
+        "Administration": {"admin": "Administrative commands"},
     }
 
     panels = []
@@ -108,6 +100,7 @@ def show_available_commands():
         panels.append(create_command_panel(group, commands))
 
     console.print(Columns(panels, equal=True, expand=True))
+
 
 def show_usage_tips():
     """Display usage tips"""
@@ -118,9 +111,10 @@ def show_usage_tips():
         "• Always [command]auth login[/command] before accessing protected resources",
         title="Usage Tips",
         border_style="green",
-        box=box.ROUNDED
+        box=box.ROUNDED,
     )
     console.print(tips_panel)
+
 
 @app.callback()
 def main(
@@ -139,6 +133,7 @@ def main(
     if version:
         try:
             from nsls2api._version import version as ver
+
             console.print(f"[info]NSLS-II API CLI version: {ver}")
         except ImportError:
             console.print("[warning]Version information not available")
@@ -152,12 +147,14 @@ def main(
         console.print()
         show_usage_tips()
 
+
 def run():
     try:
         app()
     except Exception as e:
         console.print(f"[error]Error: {str(e)}")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     run()

--- a/src/nsls2api/cli/cli.py
+++ b/src/nsls2api/cli/cli.py
@@ -1,39 +1,163 @@
-from typing import Optional
-
+import sys
 import typer
+from typing import Optional
+from rich.console import Console
+from rich.table import Table
+from rich.panel import Panel
+from rich.columns import Columns
+from rich.text import Text
+from rich.theme import Theme
+from rich.box import ROUNDED
+from rich import box
 
-from nsls2api.cli import admin, api, auth, beamline, facility, proposal, environment
+from nsls2api.cli import (
+    admin,
+    api,
+    auth,
+    beamline,
+    environment,
+    facility,
+    proposal
+)
 
-__app_name__ = "nsls2api-cli"
-__version__ = "0.1.0"
+app = typer.Typer(
+    help="NSLS-II API Command Line Interface",
+    no_args_is_help=True
+)
 
-app = typer.Typer()
-app.add_typer(admin.app, name="admin", help="Do powerful admin level magic")
-app.add_typer(api.app, name="api", help="Make NSLS-II API request")
-app.add_typer(auth.app, name="auth", help="Stuff about security and fun")
-app.add_typer(beamline.app, name="beamline", help="Stuff about Beamlines")
-app.add_typer(facility.app, name="facility", help="Stuff about Facilities")
-app.add_typer(proposal.app, name="proposal", help="Stuff about Proposals")
+# Register sub-commands
+app.add_typer(admin.app, name="admin", help="Administrative commands")
+app.add_typer(api.app, name="api", help="API status and metrics")
+app.add_typer(auth.app, name="auth", help="Authentication management")
+app.add_typer(beamline.app, name="beamline", help="Beamline operations")
+app.add_typer(environment.app, name="env", help="Environment management")
+app.add_typer(facility.app, name="facility", help="Facility operations")
+app.add_typer(proposal.app, name="proposal", help="Proposal management")
 
-# Add the new environment management commands
-app.add_typer(environment.app, name="env")
+console = Console(theme=Theme({
+    "info": "cyan",
+    "warning": "yellow",
+    "error": "red bold",
+    "success": "green bold",
+    "command": "magenta bold",
+    "subcommand": "cyan",
+    "description": "white",
+    "heading": "yellow bold",
+}))
 
+def create_command_panel(command_name: str, commands: dict) -> Panel:
+    """Create a panel for a command group"""
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("Command", style="subcommand")
+    table.add_column("Description", style="description")
+    
+    for cmd, desc in commands.items():
+        table.add_row(cmd, desc)
+    
+    return Panel(
+        table,
+        title=f"[heading]{command_name} Commands",
+        border_style="blue",
+        box=box.ROUNDED
+    )
 
-def _version_callback(value: bool) -> None:
-    if value:
-        typer.echo(f"{__app_name__} v{__version__}")
-        raise typer.Exit()
+def show_welcome():
+    """Display welcome message and version information"""
+    try:
+        from nsls2api._version import version
+        version_str = version
+    except ImportError:
+        version_str = "unknown"
 
+    welcome_panel = Panel(
+        Text("Welcome to the NSLS-II API Command Line Interface", style="info"),
+        subtitle=f"Version: {version_str}",
+        border_style="cyan",
+        box=box.DOUBLE
+    )
+    console.print(welcome_panel)
+
+def show_available_commands():
+    """Display available commands in an organized layout"""
+    command_groups = {
+        "Authentication": {
+            "auth login": "Log in to the NSLS-II API",
+            "auth logout": "Log out and remove stored credentials",
+            "auth status": "Show current authentication status"
+        },
+        "Environment": {
+            "env show": "Show current API environment",
+            "env switch": "Switch between environments (prod/dev/local)"
+        },
+        "API": {
+            "api status": "Show API status",
+            "api metrics": "Show API metrics"
+        },
+        "Resources": {
+            "beamline": "Manage beamline operations",
+            "facility": "Manage facility operations",
+            "proposal": "Manage proposals"
+        },
+        "Administration": {
+            "admin": "Administrative commands"
+        }
+    }
+
+    panels = []
+    for group, commands in command_groups.items():
+        panels.append(create_command_panel(group, commands))
+
+    console.print(Columns(panels, equal=True, expand=True))
+
+def show_usage_tips():
+    """Display usage tips"""
+    tips_panel = Panel(
+        "[info]Tips:\n"
+        "• Use [command]-h[/command] or [command]--help[/command] with any command to see detailed usage\n"
+        "• Set environment with [command]env switch[/command] before using other commands\n"
+        "• Always [command]auth login[/command] before accessing protected resources",
+        title="Usage Tips",
+        border_style="green",
+        box=box.ROUNDED
+    )
+    console.print(tips_panel)
 
 @app.callback()
 def main(
+    ctx: typer.Context,
     version: Optional[bool] = typer.Option(
         None,
         "--version",
         "-v",
-        help="Show the application's version and exit.",
-        callback=_version_callback,
+        help="Show version and exit",
         is_eager=True,
     ),
-) -> None:
-    return
+):
+    """
+    NSLS-II API Command Line Interface
+    """
+    if version:
+        try:
+            from nsls2api._version import version as ver
+            console.print(f"[info]NSLS-II API CLI version: {ver}")
+        except ImportError:
+            console.print("[warning]Version information not available")
+        raise typer.Exit()
+
+    # Only show welcome message and commands if no subcommand is specified
+    if ctx.invoked_subcommand is None:
+        show_welcome()
+        console.print()
+        show_available_commands()
+        console.print()
+        show_usage_tips()
+
+def run():
+    try:
+        app()
+    except Exception as e:
+        console.print(f"[error]Error: {str(e)}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    run()

--- a/src/nsls2api/cli/environment.py
+++ b/src/nsls2api/cli/environment.py
@@ -1,10 +1,8 @@
 import typer
 from rich.box import ROUNDED
-from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
-from rich.theme import Theme
 
 from nsls2api.cli.settings import (
     ApiEnvironment,
@@ -13,6 +11,7 @@ from nsls2api.cli.settings import (
     get_base_url,
 )
 from nsls2api.cli.utils.cli_helpers import auto_help_if_no_command
+from nsls2api.cli.utils.console import console
 
 app = typer.Typer(invoke_without_command=True)
 
@@ -21,23 +20,6 @@ app = typer.Typer(invoke_without_command=True)
 @auto_help_if_no_command()
 def environment_callback(ctx: typer.Context):
     pass  # No need to call anything manually
-
-
-console = Console(
-    theme=Theme(
-        {
-            "info": "cyan",
-            "warning": "yellow",
-            "error": "red bold",
-            "success": "green bold",
-            "url": "blue underline",
-            "env.prod": "red bold",
-            "env.dev": "yellow",
-            "env.local": "green",
-            "env.custom": "cyan",
-        }
-    )
-)
 
 
 def create_environment_table() -> Table:

--- a/src/nsls2api/cli/environment.py
+++ b/src/nsls2api/cli/environment.py
@@ -1,0 +1,40 @@
+import typer
+from nsls2api.cli.settings import (
+    ApiEnvironment,
+    Config,
+    ConfigKey,
+    get_base_url,
+)
+
+app = typer.Typer()
+
+@app.command()
+def show():
+    """Show current API environment"""
+    current_url = get_base_url()
+    if current_url == ApiEnvironment.PRODUCTION.value:
+        typer.echo(f"Current environment: production ({current_url})")
+    elif current_url == ApiEnvironment.DEVELOPMENT.value:
+        typer.echo(f"Current environment: development ({current_url})")
+    elif current_url == ApiEnvironment.LOCAL.value:
+        typer.echo(f"Current environment: local ({current_url})")
+    else:
+        typer.echo(f"Current environment: custom ({current_url})")
+
+@app.command()
+def switch(
+    env: str = typer.Argument(
+        ...,
+        help="Environment to switch to (prod/dev/local) or a custom URL"
+    )
+):
+    """Switch API environment"""
+    env_map = {
+        "prod": ApiEnvironment.PRODUCTION.value,
+        "dev": ApiEnvironment.DEVELOPMENT.value,
+        "local": ApiEnvironment.LOCAL.value,
+    }
+    
+    url = env_map.get(env.lower(), env)
+    Config.set_value("api", ConfigKey.BASE_URL, url)
+    typer.echo(f"API URL set to: {url}")

--- a/src/nsls2api/cli/environment.py
+++ b/src/nsls2api/cli/environment.py
@@ -1,12 +1,10 @@
-from enum import Enum
 import typer
+from rich.box import ROUNDED
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 from rich.theme import Theme
-from rich.style import Style
-from rich.box import ROUNDED
 
 from nsls2api.cli.settings import (
     ApiEnvironment,
@@ -16,17 +14,22 @@ from nsls2api.cli.settings import (
 )
 
 app = typer.Typer()
-console = Console(theme=Theme({
-    "info": "cyan",
-    "warning": "yellow",
-    "error": "red bold",
-    "success": "green bold",
-    "url": "blue underline",
-    "env.prod": "red bold",
-    "env.dev": "yellow",
-    "env.local": "green",
-    "env.custom": "cyan",
-}))
+console = Console(
+    theme=Theme(
+        {
+            "info": "cyan",
+            "warning": "yellow",
+            "error": "red bold",
+            "success": "green bold",
+            "url": "blue underline",
+            "env.prod": "red bold",
+            "env.dev": "yellow",
+            "env.local": "green",
+            "env.custom": "cyan",
+        }
+    )
+)
+
 
 def create_environment_table() -> Table:
     """Create a table showing all available environments"""
@@ -34,24 +37,13 @@ def create_environment_table() -> Table:
     table.add_column("Shortcut", style="cyan bold")
     table.add_column("Environment", style="green")
     table.add_column("URL", style="blue")
-    
-    table.add_row(
-        "prod",
-        "Production",
-        ApiEnvironment.PRODUCTION.value
-    )
-    table.add_row(
-        "dev",
-        "Development",
-        ApiEnvironment.DEVELOPMENT.value
-    )
-    table.add_row(
-        "local",
-        "Local",
-        ApiEnvironment.LOCAL.value
-    )
-    
+
+    table.add_row("prod", "Production", ApiEnvironment.PRODUCTION.value)
+    table.add_row("dev", "Development", ApiEnvironment.DEVELOPMENT.value)
+    table.add_row("local", "Local", ApiEnvironment.LOCAL.value)
+
     return table
+
 
 def get_environment_style(url: str) -> str:
     """Get the appropriate style for the environment"""
@@ -64,6 +56,7 @@ def get_environment_style(url: str) -> str:
     else:
         return "env.custom"
 
+
 def get_environment_name(url: str) -> str:
     """Get a friendly name for the environment"""
     if url == ApiEnvironment.PRODUCTION.value:
@@ -75,52 +68,39 @@ def get_environment_name(url: str) -> str:
     else:
         return "Custom"
 
+
 @app.command()
 def show():
     """Show current API environment"""
     current_url = get_base_url()
     env_name = get_environment_name(current_url)
     env_style = get_environment_style(current_url)
-    
+
     # Create status table
     status_table = Table(show_header=False, box=None)
     status_table.add_column("Key", style="cyan")
     status_table.add_column("Value")
-    
-    status_table.add_row(
-        "Environment",
-        Text(env_name, style=env_style)
-    )
-    status_table.add_row(
-        "URL",
-        Text(current_url, style="url")
-    )
-    
+
+    status_table.add_row("Environment", Text(env_name, style=env_style))
+    status_table.add_row("URL", Text(current_url, style="url"))
+
     # Create the main panel
-    panel = Panel(
-        status_table,
-        title="Current Environment",
-        border_style=env_style
-    )
-    
+    panel = Panel(status_table, title="Current Environment", border_style=env_style)
+
     # Show available environments
     env_table = create_environment_table()
-    env_panel = Panel(
-        env_table,
-        title="Available Environments",
-        border_style="cyan"
-    )
-    
+    env_panel = Panel(env_table, title="Available Environments", border_style="cyan")
+
     console.print(panel)
     console.print("\n[info]Available Environments:")
     console.print(env_panel)
 
+
 @app.command()
 def switch(
     env: str = typer.Argument(
-        ...,
-        help="Environment to switch to (prod/dev/local) or a custom URL"
-    )
+        ..., help="Environment to switch to (prod/dev/local) or a custom URL"
+    ),
 ):
     """Switch API environment"""
     env_map = {
@@ -128,34 +108,24 @@ def switch(
         "dev": ApiEnvironment.DEVELOPMENT.value,
         "local": ApiEnvironment.LOCAL.value,
     }
-    
+
     # If it's a known environment shortcut, use the mapped URL
     url = env_map.get(env.lower(), env)
-    
+
     with console.status("[cyan]Switching environment...", spinner="dots"):
         Config.set_value("api", ConfigKey.BASE_URL, url)
-    
+
     env_name = get_environment_name(url)
     env_style = get_environment_style(url)
-    
+
     # Create result table
     result_table = Table(show_header=False, box=None)
     result_table.add_column("Key", style="cyan")
     result_table.add_column("Value")
-    
-    result_table.add_row(
-        "New Environment",
-        Text(env_name, style=env_style)
-    )
-    result_table.add_row(
-        "URL",
-        Text(url, style="url")
-    )
-    
-    panel = Panel(
-        result_table,
-        title="Environment Switched",
-        border_style="green"
-    )
-    
+
+    result_table.add_row("New Environment", Text(env_name, style=env_style))
+    result_table.add_row("URL", Text(url, style="url"))
+
+    panel = Panel(result_table, title="Environment Switched", border_style="green")
+
     console.print(panel)

--- a/src/nsls2api/cli/environment.py
+++ b/src/nsls2api/cli/environment.py
@@ -114,7 +114,9 @@ def switch(
     """Switch API environment"""
     env_map = {
         "prod": ApiEnvironment.PRODUCTION.value,
+        "production": ApiEnvironment.PRODUCTION.value,
         "dev": ApiEnvironment.DEVELOPMENT.value,
+        "development": ApiEnvironment.DEVELOPMENT.value,
         "local": ApiEnvironment.LOCAL.value,
     }
 

--- a/src/nsls2api/cli/environment.py
+++ b/src/nsls2api/cli/environment.py
@@ -1,4 +1,13 @@
+from enum import Enum
 import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+from rich.theme import Theme
+from rich.style import Style
+from rich.box import ROUNDED
+
 from nsls2api.cli.settings import (
     ApiEnvironment,
     Config,
@@ -7,19 +16,104 @@ from nsls2api.cli.settings import (
 )
 
 app = typer.Typer()
+console = Console(theme=Theme({
+    "info": "cyan",
+    "warning": "yellow",
+    "error": "red bold",
+    "success": "green bold",
+    "url": "blue underline",
+    "env.prod": "red bold",
+    "env.dev": "yellow",
+    "env.local": "green",
+    "env.custom": "cyan",
+}))
+
+def create_environment_table() -> Table:
+    """Create a table showing all available environments"""
+    table = Table(box=ROUNDED, show_header=True)
+    table.add_column("Shortcut", style="cyan bold")
+    table.add_column("Environment", style="green")
+    table.add_column("URL", style="blue")
+    
+    table.add_row(
+        "prod",
+        "Production",
+        ApiEnvironment.PRODUCTION.value
+    )
+    table.add_row(
+        "dev",
+        "Development",
+        ApiEnvironment.DEVELOPMENT.value
+    )
+    table.add_row(
+        "local",
+        "Local",
+        ApiEnvironment.LOCAL.value
+    )
+    
+    return table
+
+def get_environment_style(url: str) -> str:
+    """Get the appropriate style for the environment"""
+    if url == ApiEnvironment.PRODUCTION.value:
+        return "env.prod"
+    elif url == ApiEnvironment.DEVELOPMENT.value:
+        return "env.dev"
+    elif url == ApiEnvironment.LOCAL.value:
+        return "env.local"
+    else:
+        return "env.custom"
+
+def get_environment_name(url: str) -> str:
+    """Get a friendly name for the environment"""
+    if url == ApiEnvironment.PRODUCTION.value:
+        return "Production"
+    elif url == ApiEnvironment.DEVELOPMENT.value:
+        return "Development"
+    elif url == ApiEnvironment.LOCAL.value:
+        return "Local"
+    else:
+        return "Custom"
 
 @app.command()
 def show():
     """Show current API environment"""
     current_url = get_base_url()
-    if current_url == ApiEnvironment.PRODUCTION.value:
-        typer.echo(f"Current environment: production ({current_url})")
-    elif current_url == ApiEnvironment.DEVELOPMENT.value:
-        typer.echo(f"Current environment: development ({current_url})")
-    elif current_url == ApiEnvironment.LOCAL.value:
-        typer.echo(f"Current environment: local ({current_url})")
-    else:
-        typer.echo(f"Current environment: custom ({current_url})")
+    env_name = get_environment_name(current_url)
+    env_style = get_environment_style(current_url)
+    
+    # Create status table
+    status_table = Table(show_header=False, box=None)
+    status_table.add_column("Key", style="cyan")
+    status_table.add_column("Value")
+    
+    status_table.add_row(
+        "Environment",
+        Text(env_name, style=env_style)
+    )
+    status_table.add_row(
+        "URL",
+        Text(current_url, style="url")
+    )
+    
+    # Create the main panel
+    panel = Panel(
+        status_table,
+        title="Current Environment",
+        border_style=env_style
+    )
+    
+    # Show available environments
+    env_table = create_environment_table()
+    env_panel = Panel(
+        env_table,
+        title="Available Environments",
+        border_style="cyan"
+    )
+    
+    console.print(panel)
+    console.print("\n[info]Available Environments:")
+    console.print(env_panel)
 
 @app.command()
 def switch(
@@ -35,6 +129,33 @@ def switch(
         "local": ApiEnvironment.LOCAL.value,
     }
     
+    # If it's a known environment shortcut, use the mapped URL
     url = env_map.get(env.lower(), env)
-    Config.set_value("api", ConfigKey.BASE_URL, url)
-    typer.echo(f"API URL set to: {url}")
+    
+    with console.status("[cyan]Switching environment...", spinner="dots"):
+        Config.set_value("api", ConfigKey.BASE_URL, url)
+    
+    env_name = get_environment_name(url)
+    env_style = get_environment_style(url)
+    
+    # Create result table
+    result_table = Table(show_header=False, box=None)
+    result_table.add_column("Key", style="cyan")
+    result_table.add_column("Value")
+    
+    result_table.add_row(
+        "New Environment",
+        Text(env_name, style=env_style)
+    )
+    result_table.add_row(
+        "URL",
+        Text(url, style="url")
+    )
+    
+    panel = Panel(
+        result_table,
+        title="Environment Switched",
+        border_style="green"
+    )
+    
+    console.print(panel)

--- a/src/nsls2api/cli/environment.py
+++ b/src/nsls2api/cli/environment.py
@@ -12,14 +12,15 @@ from nsls2api.cli.settings import (
     ConfigKey,
     get_base_url,
 )
+from nsls2api.cli.utils.cli_helpers import print_help_if_no_command
 
 app = typer.Typer(invoke_without_command=True)
 
+
 @app.callback()
-def users_callback(ctx: typer.Context):
-    if ctx.invoked_subcommand is None:
-        typer.echo(ctx.command.get_help(ctx))
-        raise typer.Exit()
+def main(ctx: typer.Context):
+    print_help_if_no_command(ctx)
+
 
 console = Console(
     theme=Theme(

--- a/src/nsls2api/cli/environment.py
+++ b/src/nsls2api/cli/environment.py
@@ -12,14 +12,15 @@ from nsls2api.cli.settings import (
     ConfigKey,
     get_base_url,
 )
-from nsls2api.cli.utils.cli_helpers import print_help_if_no_command
+from nsls2api.cli.utils.cli_helpers import auto_help_if_no_command
 
 app = typer.Typer(invoke_without_command=True)
 
 
 @app.callback()
-def main(ctx: typer.Context):
-    print_help_if_no_command(ctx)
+@auto_help_if_no_command()
+def environment_callback(ctx: typer.Context):
+    pass  # No need to call anything manually
 
 
 console = Console(

--- a/src/nsls2api/cli/environment.py
+++ b/src/nsls2api/cli/environment.py
@@ -13,7 +13,14 @@ from nsls2api.cli.settings import (
     get_base_url,
 )
 
-app = typer.Typer()
+app = typer.Typer(invoke_without_command=True)
+
+@app.callback()
+def users_callback(ctx: typer.Context):
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.command.get_help(ctx))
+        raise typer.Exit()
+
 console = Console(
     theme=Theme(
         {

--- a/src/nsls2api/cli/facility.py
+++ b/src/nsls2api/cli/facility.py
@@ -4,15 +4,16 @@ from rich.table import Table
 
 from nsls2api.api.models.facility_model import FacilityName
 from nsls2api.cli.utils.api import call_nsls2api_endpoint
-from nsls2api.cli.utils.cli_helpers import print_help_if_no_command
+from nsls2api.cli.utils.cli_helpers import auto_help_if_no_command
 from nsls2api.cli.utils.console import console, error, info, warning
 
 app = typer.Typer(invoke_without_command=True)
 
 
 @app.callback()
-def main(ctx: typer.Context):
-    print_help_if_no_command(ctx)
+@auto_help_if_no_command()
+def facility_callback(ctx: typer.Context):
+    pass  # No need to call anything manually
 
 
 @app.command()

--- a/src/nsls2api/cli/facility.py
+++ b/src/nsls2api/cli/facility.py
@@ -31,7 +31,7 @@ def cycles(facility: FacilityName):
 
     # Expecting the API to return a list of beamlines
     if response is None:
-        error("ERROR: Failed to retrieve cycle list for '{facility}' facility.")
+        error(f"ERROR: Failed to retrieve cycle list for '{facility}' facility.")
         raise typer.Exit(code=1)
 
     cycles = response.json().get("cycles", [])

--- a/src/nsls2api/cli/facility.py
+++ b/src/nsls2api/cli/facility.py
@@ -1,16 +1,59 @@
 import typer
+from rich.panel import Panel
+from rich.table import Table
 
-from nsls2api.services.facility_service import facility_cycles
+from nsls2api.api.models.facility_model import FacilityName
+from nsls2api.cli.utils.api import call_nsls2api_endpoint
+from nsls2api.cli.utils.console import console, error, info, warning
 
 app = typer.Typer()
 
 
 @app.command()
-def view(facility: str):
-    print(f"Viewing Facility: {facility}")
+def view(facility: FacilityName):
+    info(f"Viewing Facility: [green]{facility}[/green]")
 
 
 @app.command()
-def cycles(facility: str):
-    cycle_list = facility_cycles(facility)
-    return cycle_list
+def cycles(facility: FacilityName):
+    """
+    Retrieve and display a list of cycles for a facility from the API.
+    """
+    endpoint = f"v1/facility/{facility}/cycles"
+    response = call_nsls2api_endpoint(endpoint, method="GET")
+
+    # Expecting the API to return a list of beamlines
+    if response is None:
+        error("ERROR: Failed to retrieve cycle list for '{facility}' facility.")
+        raise typer.Exit(code=1)
+
+    cycles = response.json().get("cycles", [])
+
+    # Get the current operating cycle
+    current_cycle_response = call_nsls2api_endpoint(
+        f"v1/facility/{facility}/cycles/current", method="GET"
+    )
+    if current_cycle_response is None:
+        warning(
+            f"WARNING: Failed to retrieve current operating cycle for '{facility}' facility."
+        )
+        # Set current_cycle to an empty string if the API call fails
+        current_cycle = ""
+    else:
+        current_cycle = current_cycle_response.json().get("cycle", "")
+
+    table = Table(
+        title=f"Facility Cycles ({facility})",
+        show_header=True,
+        header_style="bold green",
+    )
+    table.add_column("Cycle", style="cyan", no_wrap=True)
+    table.add_column("Current Cycle", style="magenta")
+    # Adjust row extraction based on API response structure
+    for cycle in cycles:
+        # Check if the cycle is the current operating cycle
+        is_current_cycle = "Yes" if cycle == current_cycle else ""
+        table.add_row(cycle, is_current_cycle)
+    # Wrap table in a panel for a nicer output
+    panel = Panel(table, title_align="left")
+    console.print(panel)

--- a/src/nsls2api/cli/facility.py
+++ b/src/nsls2api/cli/facility.py
@@ -4,9 +4,15 @@ from rich.table import Table
 
 from nsls2api.api.models.facility_model import FacilityName
 from nsls2api.cli.utils.api import call_nsls2api_endpoint
+from nsls2api.cli.utils.cli_helpers import print_help_if_no_command
 from nsls2api.cli.utils.console import console, error, info, warning
 
-app = typer.Typer()
+app = typer.Typer(invoke_without_command=True)
+
+
+@app.callback()
+def main(ctx: typer.Context):
+    print_help_if_no_command(ctx)
 
 
 @app.command()

--- a/src/nsls2api/cli/proposal.py
+++ b/src/nsls2api/cli/proposal.py
@@ -64,13 +64,13 @@ def display_proposal(proposal: ProposalDisplay):
         user_table.add_column("PI", style="bold yellow")
 
         for user in proposal.users:
-            full_name = f"{user.first_name or ''} {user.last_name or ''}".strip()
+            full_name = f"👤 {user.first_name or ''} {user.last_name or ''}".strip()
             user_table.add_row(
                 full_name or "-",
                 user.email,
                 user.bnl_id or "-",
                 user.username or "-",
-                "⭐️ PI" if user.is_pi else "",
+                "✅" if user.is_pi else "",
             )
 
         console.print(Panel(user_table, title="👥 Proposal Users", expand=True))

--- a/src/nsls2api/cli/proposal.py
+++ b/src/nsls2api/cli/proposal.py
@@ -147,12 +147,12 @@ def view(
     response = call_nsls2api_endpoint(url, method="GET")
 
     if response is None:
-        print(f"ERROR: Failed to retrieve proposal with {lookup_type} = {identifier}.")
+        error(f"Failed to retrieve proposal with {lookup_type} = {identifier}.")
         raise typer.Exit(code=1)
 
     proposal_data = response.json().get("proposal", {})
     if not proposal_data:
-        print(f"ERROR: No data found for proposal with {lookup_type} = {identifier}.")
+        error(f"No data found for proposal with {lookup_type} = {identifier}.")
         raise typer.Exit(code=1)
 
     # Assuming Proposal is a Pydantic model

--- a/src/nsls2api/cli/proposal.py
+++ b/src/nsls2api/cli/proposal.py
@@ -158,16 +158,3 @@ def view(
     # Assuming Proposal is a Pydantic model
     proposal = ProposalDisplay(**proposal_data)
     display_proposal(proposal)
-
-
-# @app.command()
-# def search(proposal: int):
-#     print(f"Searching for Proposal: {proposal}")
-#     with Progress(
-#         SpinnerColumn(),
-#         TextColumn("[progress.description]{task.description}"),
-#         transient=True,
-#     ) as progress:
-#         progress.add_task(description="Searching...", total=None)
-#         time.sleep(3)
-#     print(f"Now showing all the awesome information about proposal {proposal}!")

--- a/src/nsls2api/cli/proposal.py
+++ b/src/nsls2api/cli/proposal.py
@@ -5,6 +5,13 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 
 app = typer.Typer()
 
+app = typer.Typer(invoke_without_command=True)
+
+@app.callback()
+def users_callback(ctx: typer.Context):
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.command.get_help(ctx))
+        raise typer.Exit()
 
 @app.command()
 def view(proposal: int):

--- a/src/nsls2api/cli/proposal.py
+++ b/src/nsls2api/cli/proposal.py
@@ -1,31 +1,139 @@
-import time
-
 import typer
-from rich.progress import Progress, SpinnerColumn, TextColumn
+from rich.panel import Panel
+from rich.table import Table
 
-app = typer.Typer()
+from nsls2api.cli.utils.api import call_nsls2api_endpoint
+from nsls2api.cli.utils.cli_helpers import auto_help_if_no_command
+from nsls2api.cli.utils.console import console
+from nsls2api.models.proposals import ProposalDisplay
 
 app = typer.Typer(invoke_without_command=True)
 
+
 @app.callback()
-def users_callback(ctx: typer.Context):
-    if ctx.invoked_subcommand is None:
-        typer.echo(ctx.command.get_help(ctx))
-        raise typer.Exit()
+@auto_help_if_no_command()
+def proposal_callback(ctx: typer.Context):
+    pass  # No need to call anything manually
+
+
+def display_proposal(proposal: ProposalDisplay):
+    # Header Panel
+    header_text = f"[bold cyan]Proposal ID:[/] {proposal.proposal_id}\n"
+    header_text += f"[bold cyan]Data Session:[/] {proposal.data_session}\n"
+    if proposal.title:
+        header_text += f"[bold cyan]Title:[/] {proposal.title}\n"
+    if proposal.type:
+        header_text += f"[bold cyan]Type:[/] {proposal.type}\n"
+    if proposal.pass_type_id:
+        header_text += f"[bold cyan]Pass Type ID:[/] {proposal.pass_type_id}"
+
+    console.print(Panel(header_text, title="Proposal Overview", expand=False))
+
+    # Instruments and Cycles
+    if proposal.instruments or proposal.cycles:
+        table = Table(title="Instruments & Cycles", expand=True)
+        table.add_column("🔬Instruments", style="green")
+        table.add_column("Cycles", style="blue")
+        max_len = max(len(proposal.instruments or []), len(proposal.cycles or []))
+        for i in range(max_len):
+            inst = (
+                proposal.instruments[i] if i < len(proposal.instruments or []) else ""
+            )
+            cyc = proposal.cycles[i] if i < len(proposal.cycles or []) else ""
+            table.add_row(inst, cyc)
+        console.print(table)
+
+    # Users 👤
+    if proposal.users:
+        user_table = Table(expand=True)
+        user_table.add_column("Name")
+        user_table.add_column("Email", style="cyan")
+        user_table.add_column("BNL ID", style="magenta")
+        user_table.add_column("Username", style="green")
+        user_table.add_column("PI", style="bold yellow")
+
+        for user in proposal.users:
+            full_name = f"{user.first_name or ''} {user.last_name or ''}".strip()
+            user_table.add_row(
+                full_name or "-",
+                user.email,
+                user.bnl_id or "-",
+                user.username or "-",
+                "⭐️ PI" if user.is_pi else "",
+            )
+
+        console.print(Panel(user_table, title="👥 Proposal Users", expand=True))
+
+    # SAFs 📎
+    if proposal.safs:
+        saf_table = Table(expand=True)
+        saf_table.add_column("SAF ID")
+        saf_table.add_column("Status")
+        saf_table.add_column("🔬Instruments")
+
+        for saf in proposal.safs:
+            instruments_str = ", ".join(saf.instruments) if saf.instruments else "-"
+            status_icon = (
+                "🟢"
+                if saf.status.lower() == "approved"
+                else "🟡"
+                if saf.status.lower() == "pending"
+                else "🔴"
+            )
+            saf_table.add_row(
+                saf.saf_id, f"{status_icon} {saf.status}", instruments_str
+            )
+
+        console.print(Panel(saf_table, title="📎 Safety Forms", expand=True))
+
+    # Slack Channels 💬
+    if proposal.slack_channels:
+        slack_table = Table(expand=True)
+        slack_table.add_column("Channel Name", style="cyan")
+        slack_table.add_column("Channel ID", style="dim")
+
+        for sc in proposal.slack_channels:
+            slack_table.add_row(f"#{sc.channel_name}", sc.channel_id)
+
+        console.print(Panel(slack_table, title="💬 Slack Integration", expand=True))
+
+    # Metadata
+    metadata_text = (
+        f"[dim]Created on:[/] {proposal.created_on.strftime('%Y-%m-%d %H:%M:%S')}\n"
+        f"[dim]Last updated:[/] {proposal.last_updated.strftime('%Y-%m-%d %H:%M:%S')}"
+    )
+    console.print(Panel(metadata_text, title="Metadata", style="dim", expand=False))
+
 
 @app.command()
-def view(proposal: int):
-    print(f"Viewing Proposal: {proposal}")
+def view(proposal_id: int):
+    print(f"Viewing Proposal: {proposal_id}")
+
+    url = f"v1/proposal/{proposal_id}"
+    response = call_nsls2api_endpoint(url, method="GET")
+
+    if response is None:
+        print(f"ERROR: Failed to retrieve proposal {proposal_id}.")
+        raise typer.Exit(code=1)
+
+    proposal_data = response.json().get("proposal", {})
+    if not proposal_data:
+        print(f"ERROR: No data found for proposal {proposal_id}.")
+        raise typer.Exit(code=1)
+
+    # Assuming Proposal is a Pydantic model
+    proposal = ProposalDisplay(**proposal_data)
+    display_proposal(proposal)
 
 
-@app.command()
-def search(proposal: int):
-    print(f"Searching for Proposal: {proposal}")
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        transient=True,
-    ) as progress:
-        progress.add_task(description="Searching...", total=None)
-        time.sleep(3)
-    print(f"Now showing all the awesome information about proposal {proposal}!")
+# @app.command()
+# def search(proposal: int):
+#     print(f"Searching for Proposal: {proposal}")
+#     with Progress(
+#         SpinnerColumn(),
+#         TextColumn("[progress.description]{task.description}"),
+#         transient=True,
+#     ) as progress:
+#         progress.add_task(description="Searching...", total=None)
+#         time.sleep(3)
+#     print(f"Now showing all the awesome information about proposal {proposal}!")

--- a/src/nsls2api/cli/settings.py
+++ b/src/nsls2api/cli/settings.py
@@ -7,7 +7,7 @@ from typing import Optional, Any
 class ApiEnvironment(str, Enum):
     PRODUCTION = "https://api.nsls2.bnl.gov"
     DEVELOPMENT = "https://api-dev.nsls2.bnl.gov"
-    LOCAL = "http://localhost:8000"
+    LOCAL = "http://127.0.0.1:8000"
 
 class ConfigKey(str, Enum):
     """Enum for configuration keys to ensure consistency"""

--- a/src/nsls2api/cli/settings.py
+++ b/src/nsls2api/cli/settings.py
@@ -1,0 +1,97 @@
+from enum import Enum
+import configparser
+import os
+from pathlib import Path
+from typing import Optional, Any
+
+class ApiEnvironment(str, Enum):
+    PRODUCTION = "https://api.nsls2.bnl.gov"
+    DEVELOPMENT = "https://api-dev.nsls2.bnl.gov"
+    LOCAL = "http://localhost:8000"
+
+class ConfigKey(str, Enum):
+    """Enum for configuration keys to ensure consistency"""
+    BASE_URL = "base_url"
+    TOKEN = "token"
+
+class Config:
+    """Centralized configuration management"""
+    
+    @staticmethod
+    def get_filepath() -> Path:
+        """Get the configuration file path"""
+        config_user_home = os.path.expanduser("~")
+        return Path(config_user_home) / ".config" / "nsls2"
+
+    @classmethod
+    def read(cls) -> configparser.ConfigParser:
+        """Read the configuration file"""
+        config = configparser.ConfigParser()
+        config_filepath = cls.get_filepath()
+        config.read(config_filepath)
+        return config
+
+    @classmethod
+    def get_value(cls, section: str, key: str) -> Optional[str]:
+        """Get a value from the configuration"""
+        try:
+            config = cls.read()
+            return config.get(section, key)
+        except (configparser.NoSectionError, configparser.NoOptionError):
+            return None
+
+    @classmethod
+    def set_value(cls, section: str, key: str, value: Any) -> None:
+        """Set a value in the configuration"""
+        config = cls.read()
+        
+        if section not in config:
+            config[section] = {}
+        
+        config[section][key] = str(value)
+        
+        # Create the directory if it doesn't exist
+        config_filepath = cls.get_filepath()
+        os.makedirs(config_filepath.parent, exist_ok=True)
+        
+        with open(config_filepath, "w") as config_file:
+            config.write(config_file)
+
+    @classmethod
+    def remove_value(cls, section: str, key: str) -> None:
+        """Remove a value from the configuration"""
+        config = cls.read()
+        
+        try:
+            if section in config and key in config[section]:
+                config.remove_option(section, key)
+                # If section becomes empty, remove it too
+                if not config.options(section):
+                    config.remove_section(section)
+                    
+                config_filepath = cls.get_filepath()
+                with open(config_filepath, "w") as config_file:
+                    config.write(config_file)
+        except Exception as e:
+            raise ConfigError(f"Error removing configuration value: {e}")
+
+def get_base_url() -> str:
+    """Get the current API base URL"""
+    url = Config.get_value("api", ConfigKey.BASE_URL)
+    return url if url else ApiEnvironment.PRODUCTION.value
+
+def get_token() -> Optional[str]:
+    """Get the API token"""
+    return Config.get_value("api", ConfigKey.TOKEN)
+
+def set_token(token: str) -> None:
+    """Set the API token"""
+    Config.set_value("api", ConfigKey.TOKEN, token)
+
+def remove_token() -> None:
+    """Remove the API token"""
+    Config.remove_value("api", ConfigKey.TOKEN)
+
+class ConfigError(Exception):
+    """Configuration related errors"""
+    pass

--- a/src/nsls2api/cli/settings.py
+++ b/src/nsls2api/cli/settings.py
@@ -1,22 +1,26 @@
-from enum import Enum
 import configparser
 import os
+from enum import Enum
 from pathlib import Path
-from typing import Optional, Any
+from typing import Any, Optional
+
 
 class ApiEnvironment(str, Enum):
     PRODUCTION = "https://api.nsls2.bnl.gov"
     DEVELOPMENT = "https://api-dev.nsls2.bnl.gov"
     LOCAL = "http://127.0.0.1:8000"
 
+
 class ConfigKey(str, Enum):
     """Enum for configuration keys to ensure consistency"""
+
     BASE_URL = "base_url"
     TOKEN = "token"
 
+
 class Config:
     """Centralized configuration management"""
-    
+
     @staticmethod
     def get_filepath() -> Path:
         """Get the configuration file path"""
@@ -44,16 +48,16 @@ class Config:
     def set_value(cls, section: str, key: str, value: Any) -> None:
         """Set a value in the configuration"""
         config = cls.read()
-        
+
         if section not in config:
             config[section] = {}
-        
+
         config[section][key] = str(value)
-        
+
         # Create the directory if it doesn't exist
         config_filepath = cls.get_filepath()
         os.makedirs(config_filepath.parent, exist_ok=True)
-        
+
         with open(config_filepath, "w") as config_file:
             config.write(config_file)
 
@@ -61,37 +65,43 @@ class Config:
     def remove_value(cls, section: str, key: str) -> None:
         """Remove a value from the configuration"""
         config = cls.read()
-        
+
         try:
             if section in config and key in config[section]:
                 config.remove_option(section, key)
                 # If section becomes empty, remove it too
                 if not config.options(section):
                     config.remove_section(section)
-                    
+
                 config_filepath = cls.get_filepath()
                 with open(config_filepath, "w") as config_file:
                     config.write(config_file)
         except Exception as e:
             raise ConfigError(f"Error removing configuration value: {e}")
 
+
 def get_base_url() -> str:
     """Get the current API base URL"""
     url = Config.get_value("api", ConfigKey.BASE_URL)
     return url if url else ApiEnvironment.PRODUCTION.value
 
+
 def get_token() -> Optional[str]:
     """Get the API token"""
     return Config.get_value("api", ConfigKey.TOKEN)
+
 
 def set_token(token: str) -> None:
     """Set the API token"""
     Config.set_value("api", ConfigKey.TOKEN, token)
 
+
 def remove_token() -> None:
     """Remove the API token"""
     Config.remove_value("api", ConfigKey.TOKEN)
 
+
 class ConfigError(Exception):
     """Configuration related errors"""
+
     pass

--- a/src/nsls2api/cli/utils/api.py
+++ b/src/nsls2api/cli/utils/api.py
@@ -30,7 +30,7 @@ def call_nsls2api_endpoint(
             console.print("[red]Access denied[/red]")
             return None
         elif exc.response.status_code == 404:
-            console.print(f"[red]Endpoint not found: {url}[/red]")
+            console.print(f"[red]Not found: {url}[/red]")
             return None
         else:
             console.print(

--- a/src/nsls2api/cli/utils/api.py
+++ b/src/nsls2api/cli/utils/api.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import httpx
+from rich.panel import Panel
 
 from nsls2api.cli.settings import get_base_url, get_token
 from nsls2api.cli.utils.console import console
@@ -24,22 +25,43 @@ def call_nsls2api_endpoint(
             response.raise_for_status()
     except httpx.HTTPStatusError as exc:
         if exc.response.status_code == 401:
-            console.print("[red]Invalid API token[/red]")
+            panel = Panel(
+                "[error]Invalid API token",
+                title="NSLS-II API Error",
+                border_style="red",
+            )
+            console.print(panel)
             return None
         elif exc.response.status_code == 403:
-            console.print("[red]Access denied[/red]")
+            panel = Panel(
+                "[error]Access denied: You do not have permission to access this resource",
+                title="NSLS-II API Error",
+                border_style="red",
+            )
+            console.print(panel)
             return None
         elif exc.response.status_code == 404:
-            console.print(f"[red]Not found: {url}[/red]")
+            panel = Panel(
+                f"[error]Not found: The requested resource '{url}' could not be found",
+                title="NSLS-II API Error",
+                border_style="red",
+            )
+            console.print(panel)
             return None
         else:
-            console.print(
-                f"[red]An error occurred while trying to contact the API: {exc}[/red]"
+            panel = Panel(
+                f"[error]An unexpected status error was returned when trying to contact the NSLS-II API: {exc}",
+                title="NSLS-II API Error",
+                border_style="red",
             )
+            console.print(panel)
             return None
     except httpx.RequestError as exc:
-        console.print(
-            f"[red]An error occurred while trying to contact the API: {exc}[/red]"
+        panel = Panel(
+            f"[error]An error occurred while trying to contact the API: {exc}",
+            title="NSLS-II API Request Error",
+            border_style="red",
         )
+        console.print(panel)
         return None
     return response

--- a/src/nsls2api/cli/utils/api.py
+++ b/src/nsls2api/cli/utils/api.py
@@ -1,0 +1,45 @@
+from typing import Optional
+
+import httpx
+
+from nsls2api.cli.settings import get_base_url, get_token
+from nsls2api.cli.utils.console import console
+
+
+def call_nsls2api_endpoint(
+    endpoint: str, method: str = "GET", data: dict = None
+) -> Optional[httpx.Response]:
+    """
+    Call the NSLS-II API endpoint and return the response.
+    """
+    url = f"{get_base_url()}/{endpoint}"
+    try:
+        with httpx.Client() as client:
+            token = get_token()
+            headers = {"Authorization": f"{token}"} if token else {}
+            if method == "GET":
+                response = client.get(url, headers=headers)
+            elif method == "POST":
+                response = client.post(url, json=data, headers=headers)
+            response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 401:
+            console.print("[red]Invalid API token[/red]")
+            return None
+        elif exc.response.status_code == 403:
+            console.print("[red]Access denied[/red]")
+            return None
+        elif exc.response.status_code == 404:
+            console.print(f"[red]Endpoint not found: {url}[/red]")
+            return None
+        else:
+            console.print(
+                f"[red]An error occurred while trying to contact the API: {exc}[/red]"
+            )
+            return None
+    except httpx.RequestError as exc:
+        console.print(
+            f"[red]An error occurred while trying to contact the API: {exc}[/red]"
+        )
+        return None
+    return response

--- a/src/nsls2api/cli/utils/cli_helpers.py
+++ b/src/nsls2api/cli/utils/cli_helpers.py
@@ -1,4 +1,20 @@
+from functools import wraps
+
 import typer
+
+
+def auto_help_if_no_command():
+    def decorator(func):
+        @wraps(func)
+        def wrapper(ctx: typer.Context, *args, **kwargs):
+            if ctx.invoked_subcommand is None:
+                typer.echo(ctx.command.get_help(ctx))
+                raise typer.Exit()
+            return func(ctx, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 def print_help_if_no_command(ctx: typer.Context):

--- a/src/nsls2api/cli/utils/cli_helpers.py
+++ b/src/nsls2api/cli/utils/cli_helpers.py
@@ -1,0 +1,7 @@
+import typer
+
+
+def print_help_if_no_command(ctx: typer.Context):
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.command.get_help(ctx))
+        raise typer.Exit()

--- a/src/nsls2api/cli/utils/console.py
+++ b/src/nsls2api/cli/utils/console.py
@@ -9,8 +9,13 @@ custom_theme = Theme(
         "info": "cyan",
         "warning": "bold yellow",
         "highlight": "bold magenta",
-        "health.good": "green bold",
-        "health.bad": "red bold",
+        "health.good": "bold green",
+        "health.bad": "bold red",
+        "url": "blue underline",
+        "env.prod": "bold red",
+        "env.dev": "yellow",
+        "env.local": "green",
+        "env.custom": "cyan",
     }
 )
 

--- a/src/nsls2api/cli/utils/console.py
+++ b/src/nsls2api/cli/utils/console.py
@@ -6,7 +6,7 @@ custom_theme = Theme(
     {
         "success": "bold green",
         "error": "bold red",
-        "info": "bold blue",
+        "info": "cyan",
         "warning": "bold yellow",
         "highlight": "bold magenta",
     }

--- a/src/nsls2api/cli/utils/console.py
+++ b/src/nsls2api/cli/utils/console.py
@@ -1,0 +1,37 @@
+from rich.console import Console
+from rich.theme import Theme
+
+# Define your custom theme
+custom_theme = Theme(
+    {
+        "success": "bold green",
+        "error": "bold red",
+        "info": "bold blue",
+        "warning": "bold yellow",
+        "highlight": "bold magenta",
+    }
+)
+
+# Instantiate the console with the theme
+console = Console(theme=custom_theme)
+
+
+# Utility functions for printing
+def success(message: str):
+    console.print(message, style="success")
+
+
+def error(message: str):
+    console.print(message, style="error")
+
+
+def info(message: str):
+    console.print(message, style="info")
+
+
+def warning(message: str):
+    console.print(message, style="warning")
+
+
+def highlight(message: str):
+    console.print(message, style="highlight")

--- a/src/nsls2api/cli/utils/console.py
+++ b/src/nsls2api/cli/utils/console.py
@@ -9,6 +9,8 @@ custom_theme = Theme(
         "info": "cyan",
         "warning": "bold yellow",
         "highlight": "bold magenta",
+        "health.good": "green bold",
+        "health.bad": "red bold",
     }
 )
 

--- a/src/nsls2api/models/proposals.py
+++ b/src/nsls2api/models/proposals.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Optional
+from typing import Optional, List
 
 import beanie
 import pydantic
@@ -22,24 +22,29 @@ class User(pydantic.BaseModel):
     username: Optional[str] = None
     is_pi: bool = False
 
-
-class Proposal(beanie.Document):
+# -- Shared Base --
+class ProposalBase(pydantic.BaseModel):
     proposal_id: str
     data_session: str
     title: Optional[str] = None
     type: Optional[str] = None
     pass_type_id: Optional[str] = None
-    instruments: Optional[list[str]] = []
-    cycles: Optional[list[str]] = []
-    users: Optional[list[User]] = []
-    safs: Optional[list[SafetyForm]] = []
-    slack_channels: Optional[list[SlackChannel]] = []
-    created_on: datetime.datetime = pydantic.Field(
-        default_factory=datetime.datetime.now
-    )
-    last_updated: datetime.datetime = pydantic.Field(
-        default_factory=datetime.datetime.now
-    )
+    instruments: Optional[List[str]] = []
+    cycles: Optional[List[str]] = []
+    users: Optional[List[User]] = []
+    safs: Optional[List[SafetyForm]] = []
+    slack_channels: Optional[List[SlackChannel]] = []
+    created_on: datetime.datetime = pydantic.Field(default_factory=datetime.datetime.now)
+    last_updated: datetime.datetime = pydantic.Field(default_factory=datetime.datetime.now)
+
+# -- Pydantic Model for Display/Transport --
+class ProposalDisplay(ProposalBase):
+    # Prevent unwanted fields (like MongoDB _id) from breaking deserialization
+    class Config:
+        extra = "ignore"
+
+# -- Beanie Model for Database --
+class Proposal(ProposalBase, beanie.Document):
 
     class Settings:
         name = "proposals"

--- a/src/nsls2api/models/proposals.py
+++ b/src/nsls2api/models/proposals.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Optional, List
+from typing import List, Optional
 
 import beanie
 import pydantic
@@ -22,6 +22,7 @@ class User(pydantic.BaseModel):
     username: Optional[str] = None
     is_pi: bool = False
 
+
 # -- Shared Base --
 class ProposalBase(pydantic.BaseModel):
     proposal_id: str
@@ -34,8 +35,13 @@ class ProposalBase(pydantic.BaseModel):
     users: Optional[List[User]] = []
     safs: Optional[List[SafetyForm]] = []
     slack_channels: Optional[List[SlackChannel]] = []
-    created_on: datetime.datetime = pydantic.Field(default_factory=datetime.datetime.now)
-    last_updated: datetime.datetime = pydantic.Field(default_factory=datetime.datetime.now)
+    created_on: datetime.datetime = pydantic.Field(
+        default_factory=datetime.datetime.now
+    )
+    last_updated: datetime.datetime = pydantic.Field(
+        default_factory=datetime.datetime.now
+    )
+
 
 # -- Pydantic Model for Display/Transport --
 class ProposalDisplay(ProposalBase):
@@ -43,9 +49,9 @@ class ProposalDisplay(ProposalBase):
     class Config:
         extra = "ignore"
 
+
 # -- Beanie Model for Database --
 class Proposal(ProposalBase, beanie.Document):
-
     class Settings:
         name = "proposals"
         indexes = [

--- a/src/nsls2api/services/slack_service.py
+++ b/src/nsls2api/services/slack_service.py
@@ -13,6 +13,7 @@ from nsls2api.models.slack_models import (
     SlackUser,
 )
 from nsls2api.services import beamline_service, proposal_service
+
 settings = get_settings()
 
 
@@ -314,7 +315,6 @@ def lookup_user_by_email(email: str) -> SlackPerson | None:
     return None
 
 
-
 def get_userid_by_username(username: str) -> Optional[str]:
     """
     Looks up the slack user_id associated with the given username.
@@ -438,7 +438,9 @@ async def create_proposal_channels(
             verified_managers = verify_slack_users(beamline_slack_managers)
 
             if len(beamline_slack_managers) != len(verified_managers):
-                verified_manager_ids = {manager.user_id for manager in verified_managers}
+                verified_manager_ids = {
+                    manager.user_id for manager in verified_managers
+                }
                 difference = set(beamline_slack_managers) - verified_manager_ids
                 logger.warning(
                     f"Failed to verify Slack accounts the following defined managers {difference} for beamline {beamline}"
@@ -500,7 +502,4 @@ async def create_proposal_channels(
 
         channels_created.append(proposal_channel)
 
-
-
     return channels_created
-


### PR DESCRIPTION
This is adding the initial 'experimental' `nsls2api` cli tool. 

It also adds a new endpoint of `/v1/beamlines` to return all the beamlines so that we can have the command `nsls2api beamline list`. 

To test the cli, first checkout this branch and `cd` to it.  Then if you have `uv` installed you should be able to simply run 

```
uv run nsls2api
```
Which should show the help screen. 

Other commands to try are:

- `uv run nsls2api api status` 
- `uv run nsls2api api metrics`
- `uv run nsls2api env show` -> Displays the current environment 
- `uv run nsls2api env switch dev` -> switch to look at the api-dev.nsls2.bnl.gov instance
- `uv run beamline view bmm` -> details on BMM
- `uv run nsls2api beamline detectors bmm` -> Detectors for BMM
- `uv run nsls2api proposal view 316832` -> Details on proposal 316832
- `uv run nsls2api facility cycles nsls2` 

Otherwise feel free to poke around.  

It is not intended for this to be deployed widely on machines at this time, but as an experiment to see if this is useful.  Once it reaches a more mature state - the intention will be to package so we can install the cli tools widely.   I would just like to merge into the code base sooner rather than later so it can be used (mainly to make my @stuartcampbell life easier 🙂 )
