### PR TITLE
API endpoint and CLI functionality to lookup a proposal using SAF ID

### DIFF
--- a/src/nsls2api/api/v1/proposal_api.py
+++ b/src/nsls2api/api/v1/proposal_api.py
@@ -16,6 +16,7 @@ from nsls2api.api.models.proposal_model import (
     SingleProposal,
     UsernamesList,
 )
+from nsls2api.infrastructure.logging import logger
 from nsls2api.infrastructure.security import get_current_user, validate_admin_role
 from nsls2api.models.slack_models import ProposalSlackChannel, SlackChannel
 from nsls2api.services import proposal_service, slack_service
@@ -127,9 +128,10 @@ async def get_proposal_by_saf(saf_id: str):
             status_code=fastapi.status.HTTP_404_NOT_FOUND, detail=e.args[0]
         )
     except Exception as e:
+        logger.error(f"An unexpected error occurred while fetching proposal by Proposal ID: {e}")
         raise HTTPException(
             status_code=fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"An error occurred: {e}",
+            detail=f"An internal server error occurred.",
         )
 
     response_model = SingleProposal(proposal=proposal)
@@ -145,9 +147,10 @@ async def get_proposal(proposal_id: str):
             status_code=fastapi.status.HTTP_404_NOT_FOUND, detail=e.args[0]
         )
     except Exception as e:
+        logger.error(f"An unexpected error occurred while fetching proposal by SAF ID: {e}")
         raise HTTPException(
             status_code=fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"An error occurred: {e}",
+            detail=f"An internal server error occurred.",
         )
 
     response_model = SingleProposal(proposal=proposal)

--- a/src/nsls2api/api/v1/proposal_api.py
+++ b/src/nsls2api/api/v1/proposal_api.py
@@ -118,6 +118,29 @@ async def get_proposals(
     return response_model
 
 
+@router.get("/proposal/saf/{saf_id}", response_model=SingleProposal)
+async def get_proposal_by_saf(saf_id: str):
+    try:
+        proposal = await proposal_service.proposal_by_saf_id(saf_id)
+        if proposal is None:
+            raise HTTPException(
+                status_code=fastapi.status.HTTP_404_NOT_FOUND,
+                detail=f"Proposal with SAF {saf_id} not found",
+            )
+    except LookupError as e:
+        raise HTTPException(
+            status_code=fastapi.status.HTTP_404_NOT_FOUND, detail=e.args[0]
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"An error occurred: {e}",
+        )
+
+    response_model = SingleProposal(proposal=proposal)
+    return response_model
+
+
 @router.get("/proposal/{proposal_id}", response_model=SingleProposal)
 async def get_proposal(proposal_id: str):
     try:

--- a/src/nsls2api/api/v1/proposal_api.py
+++ b/src/nsls2api/api/v1/proposal_api.py
@@ -122,11 +122,6 @@ async def get_proposals(
 async def get_proposal_by_saf(saf_id: str):
     try:
         proposal = await proposal_service.proposal_by_saf_id(saf_id)
-        if proposal is None:
-            raise HTTPException(
-                status_code=fastapi.status.HTTP_404_NOT_FOUND,
-                detail=f"Proposal with SAF {saf_id} not found",
-            )
     except LookupError as e:
         raise HTTPException(
             status_code=fastapi.status.HTTP_404_NOT_FOUND, detail=e.args[0]
@@ -145,11 +140,6 @@ async def get_proposal_by_saf(saf_id: str):
 async def get_proposal(proposal_id: str):
     try:
         proposal = await proposal_service.proposal_by_id(proposal_id)
-        if proposal is None:
-            raise HTTPException(
-                status_code=fastapi.status.HTTP_404_NOT_FOUND,
-                detail=f"Proposal {proposal_id} not found",
-            )
     except LookupError as e:
         raise HTTPException(
             status_code=fastapi.status.HTTP_404_NOT_FOUND, detail=e.args[0]

--- a/src/nsls2api/cli/proposal.py
+++ b/src/nsls2api/cli/proposal.py
@@ -139,8 +139,6 @@ def view(
 
     if saf:
         url = f"v1/proposal/saf/{identifier}"
-        error("Lookup by SAF ID is not yet implemented.")
-        raise typer.Exit(code=1)
     else:
         url = f"v1/proposal/{identifier}"
 
@@ -150,7 +148,7 @@ def view(
         error(f"Failed to retrieve proposal with {lookup_type} = {identifier}.")
         raise typer.Exit(code=1)
 
-    proposal_data = response.json().get("proposal", {})
+    proposal_data = response.json().get("proposal", None)
     if not proposal_data:
         error(f"No data found for proposal with {lookup_type} = {identifier}.")
         raise typer.Exit(code=1)

--- a/src/nsls2api/services/proposal_service.py
+++ b/src/nsls2api/services/proposal_service.py
@@ -178,7 +178,7 @@ async def proposal_by_id(proposal_id: str) -> Proposal:
     Retrieve a single proposal by its ID.
 
     :param proposal_id: The ID of the proposal to retrieve.
-    :return: The proposal if found, otherwise with throw a LookupError.
+    :return: The proposal if found otherwise, this function throws a LookupError.
     """
 
     proposal: Proposal = await Proposal.find_one(
@@ -196,7 +196,7 @@ async def proposal_by_saf_id(saf_id: str) -> Proposal:
     Retrieve a single proposal by its SAF ID.
 
     :param saf_id: The SAF ID of the proposal to retrieve.
-    :return: The proposal if found, otherwise with throw a LookupError.
+    :return: The proposal if found otherwise, this function throws a LookupError.
     """
 
     proposal: Proposal = await Proposal.find_one(

--- a/src/nsls2api/services/proposal_service.py
+++ b/src/nsls2api/services/proposal_service.py
@@ -173,16 +173,13 @@ async def get_slack_channels_to_create_for_proposal(
     return channel_list
 
 
-async def proposal_by_id(proposal_id: str) -> Optional[Proposal]:
+async def proposal_by_id(proposal_id: str) -> Proposal:
     """
     Retrieve a single proposal by its ID.
 
     :param proposal_id: The ID of the proposal to retrieve.
-    :return: The proposal if found, or None if not found.
+    :return: The proposal if found, otherwise with throw a LookupError.
     """
-
-    if not proposal_id:
-        return None
 
     proposal: Proposal = await Proposal.find_one(
         Proposal.proposal_id == str(proposal_id)
@@ -194,16 +191,13 @@ async def proposal_by_id(proposal_id: str) -> Optional[Proposal]:
     return proposal
 
 
-async def proposal_by_saf_id(saf_id: str) -> Optional[Proposal]:
+async def proposal_by_saf_id(saf_id: str) -> Proposal:
     """
     Retrieve a single proposal by its SAF ID.
 
     :param saf_id: The SAF ID of the proposal to retrieve.
-    :return: The proposal if found, or None if not found.
+    :return: The proposal if found, otherwise with throw a LookupError.
     """
-
-    if not saf_id:
-        return None
 
     proposal: Proposal = await Proposal.find_one(
         ElemMatch(Proposal.safs, {"saf_id": str(saf_id)})

--- a/src/nsls2api/services/proposal_service.py
+++ b/src/nsls2api/services/proposal_service.py
@@ -194,6 +194,27 @@ async def proposal_by_id(proposal_id: str) -> Optional[Proposal]:
     return proposal
 
 
+async def proposal_by_saf_id(saf_id: str) -> Optional[Proposal]:
+    """
+    Retrieve a single proposal by its SAF ID.
+
+    :param saf_id: The SAF ID of the proposal to retrieve.
+    :return: The proposal if found, or None if not found.
+    """
+
+    if not saf_id:
+        return None
+
+    proposal: Proposal = await Proposal.find_one(
+        ElemMatch(Proposal.safs, {"saf_id": str(saf_id)})
+    )
+
+    if proposal is None:
+        raise LookupError(f"Could not find a proposal with an SAF ID of {saf_id}")
+
+    return proposal
+
+
 # Get a list of proposals that match the search criteria
 async def search_proposals(search_text: str) -> Optional[list[Proposal]]:
     query = Text(search=search_text, case_sensitive=False)


### PR DESCRIPTION
This resolves #162 

This adds an endpoint to lookup a proposal by using the `saf_id` with a url of `/v1/proposal/saf/{saf_id}`.

To test the cli, first checkout this branch and cd to it. Then if you have uv installed you should be able to simply run

- `uv run nsls2api proposal view 316985` 
- `uv run nsls2api proposal view 315735 --saf` 

Both these commands should show the same info for proposal 316985
