### PR TITLE
Fix versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nsls2api"
-dynamic = ["version"]
+dynamic = ["version", "dependencies"]
 description = ''
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs", "hatch-requirements-txt"]
+requires = ["hatchling", "uv-dynamic-versioning"]
 build-backend = "hatchling.build"
 
 [project]
 name = "nsls2api"
-dynamic = ["version", "dependencies"]
+dynamic = ["version"]
 description = ''
 readme = "README.md"
 requires-python = ">=3.11"
@@ -29,15 +29,13 @@ nsls2api = "nsls2api.cli.cli:app"
 [project.urls]
 Source = "https://github.com/nsls2/nsls2api/"
 
-[tool.hatch]
-version.source = "vcs"
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
 
-[tool.hatch.metadata.hooks.requirements_txt]
-files = ["requirements.txt"]
-
-[tool.hatch.build]
-packages = ["src/nsls2api"]
-hooks.vcs.version-file = "src/nsls2api/_version.py"
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
 
 [tool.hatch.build.targets.sdist]
 exclude = [

--- a/requirements.in
+++ b/requirements.in
@@ -23,5 +23,6 @@ slack-bolt
 textual
 typer
 uuid
+uv-dynamic-versioning
 uvicorn
 Werkzeug

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,8 @@ decorator==5.2.1
     # via gssapi
 dnspython==2.7.0
     # via pymongo
+dunamai==1.24.1
+    # via uv-dynamic-versioning
 faker==37.3.0
     # via -r requirements.in
 fastapi==0.115.12
@@ -45,6 +47,8 @@ h11==0.16.0
     # via
     #   httpcore
     #   uvicorn
+hatchling==1.27.0
+    # via uv-dynamic-versioning
 httpcore==1.0.9
     # via
     #   httpx
@@ -65,6 +69,7 @@ jinja2==3.1.6
     # via
     #   -r requirements.in
     #   jinja-partials
+    #   uv-dynamic-versioning
 lazy-model==0.2.0
     # via beanie
 ldap3==2.9.1
@@ -93,11 +98,17 @@ n2snusertools==0.3.10
 packaging==25.0
     # via
     #   asgi-correlation-id
+    #   dunamai
     #   gunicorn
+    #   hatchling
 passlib==1.7.4
     # via -r requirements.in
+pathspec==0.12.1
+    # via hatchling
 platformdirs==4.3.8
     # via textual
+pluggy==1.6.0
+    # via hatchling
 prettytable==3.16.0
     # via n2snusertools
 prometheus-client==0.22.0
@@ -115,6 +126,7 @@ pydantic==2.11.5
     #   fastapi
     #   lazy-model
     #   pydantic-settings
+    #   uv-dynamic-versioning
 pydantic-core==2.33.2
     # via pydantic
 pydantic-settings==2.9.1
@@ -157,6 +169,10 @@ textual==3.2.0
     # via -r requirements.in
 toml==0.10.2
     # via beanie
+tomlkit==0.13.2
+    # via uv-dynamic-versioning
+trove-classifiers==2025.5.9.12
+    # via hatchling
 typer==0.16.0
     # via -r requirements.in
 typing-extensions==4.13.2
@@ -178,6 +194,8 @@ tzdata==2025.2
 uc-micro-py==1.0.3
     # via linkify-it-py
 uuid==1.30
+    # via -r requirements.in
+uv-dynamic-versioning==0.8.2
     # via -r requirements.in
 uvicorn==0.34.2
     # via -r requirements.in

--- a/src/nsls2api/api/v1/stats_api.py
+++ b/src/nsls2api/api/v1/stats_api.py
@@ -1,4 +1,3 @@
-import importlib.metadata
 
 import fastapi
 
@@ -14,6 +13,7 @@ from nsls2api.services import (
     facility_service,
     proposal_service,
 )
+from nsls2api.version import get_version
 
 router = fastapi.APIRouter()
 
@@ -79,7 +79,7 @@ async def stats():
 
 @router.get("/about", response_model=AboutModel)
 async def about():
-    api_version = importlib.metadata.version("nsls2api")
+    api_version = get_version()
     logger.info(f"API version: {api_version}")
     model = AboutModel(version=api_version, description="NSLS-II Facility API")
     return model

--- a/src/nsls2api/api/v1/stats_api.py
+++ b/src/nsls2api/api/v1/stats_api.py
@@ -1,4 +1,3 @@
-
 import fastapi
 
 from nsls2api.api.models.facility_model import FacilityName

--- a/src/nsls2api/api/v1/stats_api.py
+++ b/src/nsls2api/api/v1/stats_api.py
@@ -1,6 +1,7 @@
+import importlib.metadata
+
 import fastapi
 
-from nsls2api._version import version as api_version
 from nsls2api.api.models.facility_model import FacilityName
 from nsls2api.api.models.stats_model import (
     AboutModel,
@@ -78,5 +79,7 @@ async def stats():
 
 @router.get("/about", response_model=AboutModel)
 async def about():
+    api_version = importlib.metadata.version("nsls2api")
+    logger.info(f"API version: {api_version}")
     model = AboutModel(version=api_version, description="NSLS-II Facility API")
     return model

--- a/src/nsls2api/cli/cli.py
+++ b/src/nsls2api/cli/cli.py
@@ -70,15 +70,11 @@ def create_command_panel(command_name: str, commands: dict) -> Panel:
 
 def show_welcome():
     """Display welcome message and version information"""
-    try:
-        version = importlib.metadata.version("nsls2api")
-        version_str = version
-    except importlib.metadata.PackageNotFoundError:
-        version_str = "unknown"
+    version = get_version()
 
     welcome_panel = Panel(
         Text("Welcome to the NSLS-II API Command Line Interface", style="info"),
-        subtitle=f"Version: {version_str}",
+        subtitle=f"Version: {version}",
         border_style="cyan",
         box=box.DOUBLE,
     )

--- a/src/nsls2api/cli/cli.py
+++ b/src/nsls2api/cli/cli.py
@@ -14,7 +14,7 @@ from rich.theme import Theme
 from nsls2api.cli import admin, api, auth, beamline, environment, facility, proposal
 from nsls2api.version import get_version
 
-# Remove no_args_is_help and add invoke_without_command to allow version option without subcommand.
+# Remove no_args_is_help and add invoke_without_command to allow a version option without subcommand.
 app = typer.Typer(
     help="NSLS-II API Command Line Interface", invoke_without_command=True
 )
@@ -138,7 +138,7 @@ def main(
             console.print("[warning]Version information not available")
         raise typer.Exit()
 
-    # Only show welcome message and commands if no subcommand is specified
+    # Only show a welcome message and commands if no subcommand is specified
     if ctx.invoked_subcommand is None:
         show_welcome()
         console.print()

--- a/src/nsls2api/cli/cli.py
+++ b/src/nsls2api/cli/cli.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import sys
 from typing import Optional
 
@@ -12,7 +13,10 @@ from rich.theme import Theme
 
 from nsls2api.cli import admin, api, auth, beamline, environment, facility, proposal
 
-app = typer.Typer(help="NSLS-II API Command Line Interface", no_args_is_help=True)
+# Remove no_args_is_help and add invoke_without_command to allow version option without subcommand.
+app = typer.Typer(
+    help="NSLS-II API Command Line Interface", invoke_without_command=True
+)
 
 # Register sub-commands
 app.add_typer(admin.app, name="admin", help="Administrative commands")
@@ -39,6 +43,14 @@ console = Console(
 )
 
 
+def get_version() -> str:
+    """Get the version of the nsls2api package"""
+    try:
+        return importlib.metadata.version("nsls2api")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
 def create_command_panel(command_name: str, commands: dict) -> Panel:
     """Create a panel for a command group"""
     table = Table(show_header=False, box=None, padding=(0, 2))
@@ -59,7 +71,7 @@ def create_command_panel(command_name: str, commands: dict) -> Panel:
 def show_welcome():
     """Display welcome message and version information"""
     try:
-        from nsls2api._version import version
+        version = importlib.metadata.version("nsls2api")
 
         version_str = version
     except ImportError:
@@ -132,10 +144,9 @@ def main(
     """
     if version:
         try:
-            from nsls2api._version import version as ver
-
-            console.print(f"[info]NSLS-II API CLI version: {ver}")
-        except ImportError:
+            version = importlib.metadata.version("nsls2api")
+            console.print(f"[info]NSLS-II API CLI version: {version}")
+        except importlib.metadata.PackageNotFoundError:
             console.print("[warning]Version information not available")
         raise typer.Exit()
 

--- a/src/nsls2api/cli/cli.py
+++ b/src/nsls2api/cli/cli.py
@@ -72,9 +72,8 @@ def show_welcome():
     """Display welcome message and version information"""
     try:
         version = importlib.metadata.version("nsls2api")
-
         version_str = version
-    except ImportError:
+    except importlib.metadata.PackageNotFoundError:
         version_str = "unknown"
 
     welcome_panel = Panel(

--- a/src/nsls2api/cli/cli.py
+++ b/src/nsls2api/cli/cli.py
@@ -131,11 +131,8 @@ def main(
     NSLS-II API Command Line Interface
     """
     if version:
-        try:
-            version = get_version()
-            console.print(f"[info]NSLS-II API CLI version: {version}")
-        except importlib.metadata.PackageNotFoundError:
-            console.print("[warning]Version information not available")
+        version = get_version()
+        console.print(f"[info]NSLS-II API CLI version: {version}")
         raise typer.Exit()
 
     # Only show a welcome message and commands if no subcommand is specified

--- a/src/nsls2api/cli/cli.py
+++ b/src/nsls2api/cli/cli.py
@@ -1,4 +1,3 @@
-import importlib.metadata
 import sys
 from typing import Optional
 

--- a/src/nsls2api/cli/cli.py
+++ b/src/nsls2api/cli/cli.py
@@ -12,6 +12,7 @@ from rich.text import Text
 from rich.theme import Theme
 
 from nsls2api.cli import admin, api, auth, beamline, environment, facility, proposal
+from nsls2api.version import get_version
 
 # Remove no_args_is_help and add invoke_without_command to allow version option without subcommand.
 app = typer.Typer(
@@ -41,14 +42,6 @@ console = Console(
         }
     )
 )
-
-
-def get_version() -> str:
-    """Get the version of the nsls2api package"""
-    try:
-        return importlib.metadata.version("nsls2api")
-    except importlib.metadata.PackageNotFoundError:
-        return "unknown"
 
 
 def create_command_panel(command_name: str, commands: dict) -> Panel:

--- a/src/nsls2api/cli/cli.py
+++ b/src/nsls2api/cli/cli.py
@@ -132,7 +132,7 @@ def main(
     """
     if version:
         try:
-            version = importlib.metadata.version("nsls2api")
+            version = get_version()
             console.print(f"[info]NSLS-II API CLI version: {version}")
         except importlib.metadata.PackageNotFoundError:
             console.print("[warning]Version information not available")

--- a/src/nsls2api/version.py
+++ b/src/nsls2api/version.py
@@ -1,0 +1,9 @@
+import importlib.metadata
+
+
+def get_version() -> str:
+    """Get the version of the nsls2api package"""
+    try:
+        return importlib.metadata.version("nsls2api")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"


### PR DESCRIPTION
The method I was using for dynamic versioning didn't seem to be working reliably.  This PR changes the method to use a different package for version determination. 

This also fixed an issue with the CLI where just running the command with no command and a flag would return an error (i.e. the `--version` would always fail)

## To Test 

If you checkout the branch, cd into it and then type `uv run nsls2api --version` should return the version.

Also, if you stand up the server, then the `/v1/about` endpoint should also return the version. 

