### PR TITLE
Update pass ORCiD changes

### DIFF
--- a/src/nsls2api/models/pass_models.py
+++ b/src/nsls2api/models/pass_models.py
@@ -24,6 +24,7 @@ class PassPerson(pydantic.BaseModel):
     First_Name: Optional[str] = None
     Last_Name: Optional[str] = None
     User_Facility_ID: Optional[str] = None
+    ORCID_ID: Optional[str] = None
 
 
 class PassAllocation(pydantic.BaseModel):
@@ -92,6 +93,7 @@ class PassExperimenter(pydantic.BaseModel):
     First_Name: Optional[str] = None
     Last_Name: Optional[str] = None
     User_Facility_ID: Optional[str] = None
+    ORCID_ID: Optional[str] = None
 
 
 class PassResource(pydantic.BaseModel):

--- a/src/nsls2api/models/proposals.py
+++ b/src/nsls2api/models/proposals.py
@@ -21,6 +21,7 @@ class User(pydantic.BaseModel):
     bnl_id: Optional[str] = None
     username: Optional[str] = None
     is_pi: bool = False
+    orcid: Optional[str] = None
 
 
 # -- Shared Base --


### PR DESCRIPTION
These changes are to make use of the ORCiD field that will soon be added into the PASS Person and Experimenter models that are used in their API. 

These changes should just add a field `orcid` into the user entry within the proposal document which will be `null` if the PASS API does not contain this information - or hopefully will contain the actual value if it is there 😄. 

I have also fixed some code warnings that ruff was complaining about. 