### PR TITLE
Add beamline difference check

### DIFF
--- a/.github/workflows/data-consistency-workflow.yml
+++ b/.github/workflows/data-consistency-workflow.yml
@@ -4,7 +4,7 @@ permissions:
 
 on:
   schedule:
-    - cron: '*/45 * * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/data-consistency-workflow.yml
+++ b/.github/workflows/data-consistency-workflow.yml
@@ -1,0 +1,38 @@
+name: Check Data Consistency in API between Development and Production
+permissions:
+  contents: read
+
+on:
+  schedule:
+    - cron: '*/45 * * * *'
+  workflow_dispatch:
+
+jobs:
+  integration_tests:
+    runs-on: self-hosted
+
+    steps:
+    - name: Print hostname
+      run: echo "The hostname is $(hostname)"
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'zulu'
+        java-version: '21'
+
+    - name: Download ijhttp.zip
+      run: curl -f -L -o ijhttp.zip "https://jb.gg/ijhttp/latest"
+
+    - name: Unzip ijhttp.zip
+      run: unzip -q ijhttp.zip
+
+    - name: Check Beamlines Differences
+      run: |
+        ./ijhttp/ijhttp \
+        ./integration-tests/check_beamlines_differences.http

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This is the repository for the NSLS-II Facility API codebase.
 
 [![Integration Tests for DEV API](https://github.com/NSLS2/nsls2api/actions/workflows/test-dev-deployment.yml/badge.svg)](https://github.com/NSLS2/nsls2api/actions/workflows/test-dev-deployment.yml)
 
+[![Data Consistency Checks between DEV and PROD APIs](https://github.com/NSLS2/nsls2api/actions/workflows/data-consistency-workflow.yml/badge.svg)](https://github.com/NSLS2/nsls2api/actions/workflows/data-consistency-workflow.yml)
+
+
 ## Developer Notes
 
 In order to develop locally you will need to have a local MongoDB running.  

--- a/integration-tests/check_beamlines_differences.http
+++ b/integration-tests/check_beamlines_differences.http
@@ -1,0 +1,89 @@
+@devHost = https://api-dev.nsls2.bnl.gov
+@prodHost = https://api.nsls2.bnl.gov
+
+### 1. Fetch beamlines from DEV and stash raw JSON
+GET {{devHost}}/v1/beamlines
+Accept: application/json
+
+> {%
+  client.global.set("devRaw", JSON.stringify(response.body));
+%}
+
+### 2. Fetch beamlines from PROD and diff, showing only changed fields + name
+GET {{prodHost}}/v1/beamlines
+Accept: application/json
+
+> {%
+  const ignore = ["created_on", "last_updated"];
+
+  function prune(x) {
+    if (Array.isArray(x)) return x.map(prune);
+    if (x && typeof x === "object") {
+      const out = {};
+      for (const k of Object.keys(x)) {
+        if (!ignore.includes(k)) out[k] = prune(x[k]);
+      }
+      return out;
+    }
+    return x;
+  }
+
+  const devList  = prune(JSON.parse(client.global.get("devRaw")));
+  const prodList = prune(response.body);
+
+  const devMap  = new Map(devList.map(o => [o._id, o]));
+  const prodMap = new Map(prodList.map(o => [o._id, o]));
+
+  function diffObject(a, b) {
+    const allKeys = new Set([...Object.keys(a), ...Object.keys(b)]);
+    const diffs = {};
+    for (const key of allKeys) {
+      if (JSON.stringify(a[key]) !== JSON.stringify(b[key])) {
+        diffs[key] = { dev: a[key], prod: b[key] };
+      }
+    }
+    return diffs;
+  }
+
+  const diffs = [];
+  // check for missing or changed
+  for (const [id, devItem] of devMap) {
+    const prodItem = prodMap.get(id);
+    if (!prodItem) {
+      diffs.push({
+        _id: id,
+        name: devItem.name,
+        status: "missingInProd"
+      });
+    }
+    else {
+      const changed = diffObject(devItem, prodItem);
+      if (Object.keys(changed).length) {
+        diffs.push({
+          _id: id,
+          name: devItem.name,
+          status: "mismatch",
+          diff: changed
+        });
+      }
+    }
+  }
+  // check for new in prod
+  for (const [id, prodItem] of prodMap) {
+    if (!devMap.has(id)) {
+      diffs.push({
+        _id: id,
+        name: prodItem.name,
+        status: "newInProd"
+      });
+    }
+  }
+
+  client.test("DEV vs PROD (only listing actual differences, with names)", () => {
+    client.assert(
+      diffs.length === 0,
+      `Found ${diffs.length} difference(s):\n` +
+      JSON.stringify(diffs, null, 2)
+    );
+  });
+%}


### PR DESCRIPTION
This check/test checks the differences in the output for the `/v1/beamlines` endpoint on both the development and production API instances.  

This hopefully will pickup and highlight any database data inconsistencies that may creep in. 