### PR TITLE
Drop support for Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.11"
           - "3.12"
           - "3.13"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "nsls2api"
 dynamic = ["version", "dependencies"]
 description = ''
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = "BSD-3-Clause"
 authors = [
     { name = "Stuart Campbell", email = "scampbell@bnl.gov" },
@@ -17,7 +17,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
@@ -57,7 +56,7 @@ exclude = [
 #dev = ["requirements-dev.txt"]
 
 [tool.black]
-target_version = ['py311']
+target_version = ['py312']
 include = '\.pyi?$'
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
As we don't deploy on 3.11 anywhere - remove support for it and make the minimum supported version 3.12