### PR TITLE
Move locking endpoints to admin 

### DIFF
--- a/src/nsls2api/api/v1/admin_api.py
+++ b/src/nsls2api/api/v1/admin_api.py
@@ -6,10 +6,10 @@ from starlette.responses import Response
 
 from nsls2api.api.models.facility_model import FacilityName
 from nsls2api.api.models.proposal_model import (
-    SingleProposal,
+    LockedProposalsList,
     ProposalChangeResultsList,
     ProposalsToChangeList,
-    LockedProposalsList,
+    SingleProposal,
 )
 from nsls2api.api.v1.proposal_api import router
 from nsls2api.infrastructure import config
@@ -23,7 +23,7 @@ from nsls2api.models.apikeys import (
     ApiUserRole,
     ApiUserType,
 )
-from nsls2api.services import proposal_service, facility_service, beamline_service
+from nsls2api.services import beamline_service, facility_service, proposal_service
 
 # router = fastapi.APIRouter()
 router = fastapi.APIRouter(

--- a/src/nsls2api/api/v1/admin_api.py
+++ b/src/nsls2api/api/v1/admin_api.py
@@ -1,10 +1,17 @@
 from typing import Annotated, Optional
 
 import fastapi
-from fastapi import Depends, HTTPException
+from fastapi import Depends, HTTPException, Query
+from starlette.responses import Response
 
 from nsls2api.api.models.facility_model import FacilityName
-from nsls2api.api.models.proposal_model import SingleProposal
+from nsls2api.api.models.proposal_model import (
+    SingleProposal,
+    ProposalChangeResultsList,
+    ProposalsToChangeList,
+    LockedProposalsList,
+)
+from nsls2api.api.v1.proposal_api import router
 from nsls2api.infrastructure import config
 from nsls2api.infrastructure.security import (
     generate_api_key,
@@ -16,7 +23,7 @@ from nsls2api.models.apikeys import (
     ApiUserRole,
     ApiUserType,
 )
-from nsls2api.services import proposal_service
+from nsls2api.services import proposal_service, facility_service, beamline_service
 
 # router = fastapi.APIRouter()
 router = fastapi.APIRouter(
@@ -104,3 +111,168 @@ async def update_user_role(username: str, role: ApiUserRole) -> ApiUserResponseM
     )
 
     return response
+
+
+@router.put(
+    "/admin/proposals/cycle/lock/{cycle_name}/{facility}",
+    response_model=ProposalChangeResultsList,
+    dependencies=[Depends(validate_admin_role)],
+)
+async def lock_cycle(cycle_name: str, facility: str):
+    cycle = await facility_service.cycle_exists(
+        cycle_name=cycle_name, facility=facility
+    )
+    if not cycle:
+        raise HTTPException(
+            status_code=fastapi.status.HTTP_404_NOT_FOUND,
+            detail=f"Cycle {cycle_name} not found",
+        )
+    proposals_at_cycle = await proposal_service.fetch_proposals(cycle=[cycle_name])
+    proposal_list = ProposalsToChangeList(
+        proposals_to_change=[proposal.proposal_id for proposal in proposals_at_cycle]
+    )
+    locked_info = await proposal_service.lock(proposal_list)
+    return locked_info
+
+
+@router.put(
+    "/admin/proposals/cycle/unlock/{cycle_name}/{facility}",
+    response_model=ProposalChangeResultsList,
+    dependencies=[Depends(validate_admin_role)],
+)
+async def unlock_cycle(cycle_name: str, facility: str):
+    cycle = await facility_service.cycle_exists(
+        cycle_name=cycle_name, facility=facility
+    )
+    if not cycle:
+        raise HTTPException(
+            status_code=fastapi.status.HTTP_404_NOT_FOUND,
+            detail=f"Cycle {cycle_name} not found",
+        )
+    proposals_at_cycle = await proposal_service.fetch_proposals(cycle=[cycle_name])
+    proposal_list = ProposalsToChangeList(
+        proposals_to_change=[proposal.proposal_id for proposal in proposals_at_cycle]
+    )
+    unlocked_info = await proposal_service.unlock(proposal_list)
+    return unlocked_info
+
+
+@router.put(
+    "/admin/proposals/beamline/unlock/{beamline_name}",
+    response_model=ProposalChangeResultsList,
+    dependencies=[Depends(validate_admin_role)],
+)
+async def unlock_beamline(beamline_name: str):
+    beamline = await beamline_service.beamline_by_name(beamline_name)
+    if beamline is None:
+        raise HTTPException(
+            status_code=fastapi.status.HTTP_404_NOT_FOUND,
+            detail=f"Beamline {beamline_name} not found",
+        )
+    proposals_at_beamline = await proposal_service.fetch_proposals(
+        beamline=[beamline_name]
+    )
+    proposal_list = ProposalsToChangeList(
+        proposals_to_change=[proposal.proposal_id for proposal in proposals_at_beamline]
+    )
+    unlocked_info = await proposal_service.unlock(proposal_list)
+    return unlocked_info
+
+
+@router.put(
+    "/admin/proposals/beamline/lock/{beamline_name}",
+    response_model=ProposalChangeResultsList,
+    dependencies=[Depends(validate_admin_role)],
+)
+async def lock_beamline(beamline_name: str):
+    beamline = await beamline_service.beamline_by_name(beamline_name)
+    if beamline is None:
+        raise HTTPException(
+            status_code=fastapi.status.HTTP_404_NOT_FOUND,
+            detail=f"Beamline {beamline_name} not found",
+        )
+    proposals_at_beamline = await proposal_service.fetch_proposals(
+        beamline=[beamline_name]
+    )
+    proposal_list = ProposalsToChangeList(
+        proposals_to_change=[proposal.proposal_id for proposal in proposals_at_beamline]
+    )
+    locked_info = await proposal_service.lock(proposal_list)
+    return locked_info
+
+
+@router.put(
+    "/admin/proposals/lock",
+    response_model=ProposalChangeResultsList,
+    dependencies=[Depends(validate_admin_role)],
+)
+async def lock(proposal_list: ProposalsToChangeList, response: Response):
+    unknown_proposals = [
+        proposal
+        for proposal in proposal_list.proposals_to_change
+        if not await proposal_service.exists(proposal)
+    ]
+    if unknown_proposals:
+        raise HTTPException(
+            status_code=fastapi.status.HTTP_404_NOT_FOUND,
+            detail=f"Proposals {unknown_proposals} not found. No action taken.",
+        )
+    locked_info = await proposal_service.lock(proposal_list)
+    if locked_info.failed_proposals:
+        response.status_code = fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY
+    return locked_info
+
+
+@router.get("/admin/proposals/locked", response_model=LockedProposalsList)
+async def gather_locked_proposals(
+    facility: str,
+    beamlines: Annotated[list[str], Query()] = [],
+    cycles: Annotated[list[str], Query()] = [],
+):
+    for beamline_name in beamlines:
+        beamline = await beamline_service.beamline_by_name(beamline_name)
+        if beamline is None:
+            raise HTTPException(
+                status_code=fastapi.status.HTTP_404_NOT_FOUND,
+                detail=f"Beamline {beamline_name} not found",
+            )
+    for cycle_name in cycles:
+        if not await facility_service.cycle_exists(
+            cycle_name=cycle_name, facility=facility
+        ):
+            raise HTTPException(
+                status_code=fastapi.status.HTTP_404_NOT_FOUND,
+                detail=f"Cycle {cycle_name} not found",
+            )
+    locked_proposals = await proposal_service.get_locked_proposals(
+        cycles=cycles, beamlines=beamlines
+    )
+    locked_proposals_list = locked_proposals.locked_proposals
+    if locked_proposals_list is None:
+        raise HTTPException(
+            status_code=fastapi.status.HTTP_204_NO_CONTENT,
+            detail="No locked proposals found",
+        )
+    return locked_proposals
+
+
+@router.put(
+    "/admin/proposals/unlock",
+    response_model=ProposalChangeResultsList,
+    dependencies=[Depends(validate_admin_role)],
+)
+async def unlock(proposal_list: ProposalsToChangeList, response: Response):
+    unknown_proposals = [
+        proposal
+        for proposal in proposal_list.proposals_to_change
+        if not await proposal_service.exists(proposal)
+    ]
+    if unknown_proposals:
+        raise HTTPException(
+            status_code=fastapi.status.HTTP_404_NOT_FOUND,
+            detail=f"Proposals {unknown_proposals} not found. No action taken.",
+        )
+    unlocked_info = await proposal_service.unlock(proposal_list)
+    if unlocked_info.failed_proposals:
+        response.status_code = fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY
+    return unlocked_info

--- a/src/nsls2api/api/v1/proposal_api.py
+++ b/src/nsls2api/api/v1/proposal_api.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Annotated
 
 import fastapi
-from fastapi import Depends, HTTPException, Query, Response
+from fastapi import Depends, HTTPException, Query
 
 from nsls2api.api.models.facility_model import FacilityName
 from nsls2api.api.models.proposal_model import (
@@ -15,9 +15,6 @@ from nsls2api.api.models.proposal_model import (
     RecentProposalsList,
     SingleProposal,
     UsernamesList,
-    LockedProposalsList,
-    ProposalChangeResultsList,
-    ProposalsToChangeList,
 )
 from nsls2api.infrastructure.logging import logger
 from nsls2api.infrastructure.security import get_current_user, validate_admin_role
@@ -29,8 +26,6 @@ from nsls2api.models.slack_models import (
 from nsls2api.services import (
     proposal_service,
     slack_service,
-    beamline_service,
-    facility_service,
 )
 from nsls2api.services.slack_service import get_conversation_details
 
@@ -351,168 +346,3 @@ async def create_slack_channels_for_proposal(
     await proposal.save()  # noqa - we don't need to specify any args here
 
     return channels
-
-
-@router.put(
-    "/proposals/lock",
-    response_model=ProposalChangeResultsList,
-    dependencies=[Depends(validate_admin_role)],
-)
-async def lock(proposal_list: ProposalsToChangeList, response: Response):
-    unknown_proposals = [
-        proposal
-        for proposal in proposal_list.proposals_to_change
-        if not await proposal_service.exists(proposal)
-    ]
-    if unknown_proposals:
-        raise HTTPException(
-            status_code=fastapi.status.HTTP_404_NOT_FOUND,
-            detail=f"Proposals {unknown_proposals} not found. No action taken.",
-        )
-    locked_info = await proposal_service.lock(proposal_list)
-    if locked_info.failed_proposals:
-        response.status_code = fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY
-    return locked_info
-
-
-@router.get("/proposals/locked", response_model=LockedProposalsList)
-async def gather_locked_proposals(
-    facility: str,
-    beamlines: Annotated[list[str], Query()] = [],
-    cycles: Annotated[list[str], Query()] = [],
-):
-    for beamline_name in beamlines:
-        beamline = await beamline_service.beamline_by_name(beamline_name)
-        if beamline is None:
-            raise HTTPException(
-                status_code=fastapi.status.HTTP_404_NOT_FOUND,
-                detail=f"Beamline {beamline_name} not found",
-            )
-    for cycle_name in cycles:
-        if not await facility_service.cycle_exists(
-            cycle_name=cycle_name, facility=facility
-        ):
-            raise HTTPException(
-                status_code=fastapi.status.HTTP_404_NOT_FOUND,
-                detail=f"Cycle {cycle_name} not found",
-            )
-    locked_proposals = await proposal_service.get_locked_proposals(
-        cycles=cycles, beamlines=beamlines
-    )
-    locked_proposals_list = locked_proposals.locked_proposals
-    if locked_proposals_list is None:
-        raise HTTPException(
-            status_code=fastapi.status.HTTP_204_NO_CONTENT,
-            detail="No locked proposals found",
-        )
-    return locked_proposals
-
-
-@router.put(
-    "/proposals/unlock",
-    response_model=ProposalChangeResultsList,
-    dependencies=[Depends(validate_admin_role)],
-)
-async def unlock(proposal_list: ProposalsToChangeList, response: Response):
-    unknown_proposals = [
-        proposal
-        for proposal in proposal_list.proposals_to_change
-        if not await proposal_service.exists(proposal)
-    ]
-    if unknown_proposals:
-        raise HTTPException(
-            status_code=fastapi.status.HTTP_404_NOT_FOUND,
-            detail=f"Proposals {unknown_proposals} not found. No action taken.",
-        )
-    unlocked_info = await proposal_service.unlock(proposal_list)
-    if unlocked_info.failed_proposals:
-        response.status_code = fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY
-    return unlocked_info
-
-
-@router.put(
-    "/proposals/beamline/lock/{beamline_name}",
-    response_model=ProposalChangeResultsList,
-    dependencies=[Depends(validate_admin_role)],
-)
-async def lock_beamline(beamline_name: str):
-    beamline = await beamline_service.beamline_by_name(beamline_name)
-    if beamline is None:
-        raise HTTPException(
-            status_code=fastapi.status.HTTP_404_NOT_FOUND,
-            detail=f"Beamline {beamline_name} not found",
-        )
-    proposals_at_beamline = await proposal_service.fetch_proposals(
-        beamline=[beamline_name]
-    )
-    proposal_list = ProposalsToChangeList(
-        proposals_to_change=[proposal.proposal_id for proposal in proposals_at_beamline]
-    )
-    locked_info = await proposal_service.lock(proposal_list)
-    return locked_info
-
-
-@router.put(
-    "/proposals/beamline/unlock/{beamline_name}",
-    response_model=ProposalChangeResultsList,
-    dependencies=[Depends(validate_admin_role)],
-)
-async def unlock_beamline(beamline_name: str):
-    beamline = await beamline_service.beamline_by_name(beamline_name)
-    if beamline is None:
-        raise HTTPException(
-            status_code=fastapi.status.HTTP_404_NOT_FOUND,
-            detail=f"Beamline {beamline_name} not found",
-        )
-    proposals_at_beamline = await proposal_service.fetch_proposals(
-        beamline=[beamline_name]
-    )
-    proposal_list = ProposalsToChangeList(
-        proposals_to_change=[proposal.proposal_id for proposal in proposals_at_beamline]
-    )
-    unlocked_info = await proposal_service.unlock(proposal_list)
-    return unlocked_info
-
-
-@router.put(
-    "/proposals/cycle/lock/{cycle_name}/{facility}",
-    response_model=ProposalChangeResultsList,
-    dependencies=[Depends(validate_admin_role)],
-)
-async def lock_cycle(cycle_name: str, facility: str):
-    cycle = await facility_service.cycle_exists(
-        cycle_name=cycle_name, facility=facility
-    )
-    if not cycle:
-        raise HTTPException(
-            status_code=fastapi.status.HTTP_404_NOT_FOUND,
-            detail=f"Cycle {cycle_name} not found",
-        )
-    proposals_at_cycle = await proposal_service.fetch_proposals(cycle=[cycle_name])
-    proposal_list = ProposalsToChangeList(
-        proposals_to_change=[proposal.proposal_id for proposal in proposals_at_cycle]
-    )
-    locked_info = await proposal_service.lock(proposal_list)
-    return locked_info
-
-
-@router.put(
-    "/proposals/cycle/unlock/{cycle_name}/{facility}",
-    response_model=ProposalChangeResultsList,
-    dependencies=[Depends(validate_admin_role)],
-)
-async def unlock_cycle(cycle_name: str, facility: str):
-    cycle = await facility_service.cycle_exists(
-        cycle_name=cycle_name, facility=facility
-    )
-    if not cycle:
-        raise HTTPException(
-            status_code=fastapi.status.HTTP_404_NOT_FOUND,
-            detail=f"Cycle {cycle_name} not found",
-        )
-    proposals_at_cycle = await proposal_service.fetch_proposals(cycle=[cycle_name])
-    proposal_list = ProposalsToChangeList(
-        proposals_to_change=[proposal.proposal_id for proposal in proposals_at_cycle]
-    )
-    unlocked_info = await proposal_service.unlock(proposal_list)
-    return unlocked_info

--- a/src/nsls2api/tests/api/test_admin_api.py
+++ b/src/nsls2api/tests/api/test_admin_api.py
@@ -5,11 +5,9 @@ from nsls2api.main import app
 from nsls2api.api.models.proposal_model import (
     ProposalChangeResultsList,
     LockedProposalsList,
-    ProposalFullDetailsList
+    ProposalFullDetailsList,
 )
-from nsls2api.services import (
-    proposal_service
-)
+from nsls2api.services import proposal_service
 from nsls2api.models.apikeys import ApiKey
 import os
 
@@ -24,66 +22,82 @@ facility = "nsls2"
 
 @pytest.mark.anyio
 async def test_lock_and_unlock_proposals():
-    #resetting to ensure locked is false
+    # resetting to ensure locked is false
     key = await ApiKey.find_one(ApiKey.username == "test_user")
     data_start = {"proposals_to_change": [test_proposal_id]}
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
-        response_start = await ac.put( f"/v1/proposals/unlock",
-                json=data_start,headers={"Authorization": key.secret_key})
-        
+        response_start = await ac.put(
+            f"/v1/proposals/unlock",
+            json=data_start,
+            headers={"Authorization": key.secret_key},
+        )
+
     response_start_json = response_start.json()
     assert response_start.status_code == 200
     unlocked_proposals_info = ProposalChangeResultsList(**response_start_json)
     assert unlocked_proposals_info.successful_proposals == [test_proposal_id]
-    proposal_objects_start = await proposal_service.fetch_proposals(proposal_id = [test_proposal_id])
+    proposal_objects_start = await proposal_service.fetch_proposals(
+        proposal_id=[test_proposal_id]
+    )
     assert proposal_objects_start[0].locked == False
 
-    #locking
+    # locking
     data_lock = {"proposals_to_change": [test_proposal_id]}
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
-        response_lock = await ac.put( f"/v1/proposals/lock",
-                json=data_lock,headers={"Authorization": key.secret_key})
-        
+        response_lock = await ac.put(
+            f"/v1/proposals/lock",
+            json=data_lock,
+            headers={"Authorization": key.secret_key},
+        )
+
     response_lock_json = response_lock.json()
     assert response_lock.status_code == 200
     locked_proposals_info = ProposalChangeResultsList(**response_lock_json)
     assert locked_proposals_info.successful_proposals == [test_proposal_id]
-    proposal_objects = await proposal_service.fetch_proposals(proposal_id = [test_proposal_id])
+    proposal_objects = await proposal_service.fetch_proposals(
+        proposal_id=[test_proposal_id]
+    )
     assert proposal_objects[0].locked == True
 
-    #gathering locked proposals
-    facility_name = "nsls2",
+    # gathering locked proposals
+    facility_name = ("nsls2",)
     beamline = ["ZZZ"]
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
         response_get_list = await ac.get(
-            f"/v1/proposals/locked?beamline={beamline}&facility={facility_name}",headers={"Authorization": key.secret_key}
+            f"/v1/proposals/locked?beamline={beamline}&facility={facility_name}",
+            headers={"Authorization": key.secret_key},
         )
     response_get_list_json = response_get_list.json()
     assert response_get_list.status_code == 200
     locked_proposals_list = LockedProposalsList(**response_get_list_json)
-    assert locked_proposals_list.locked_proposals[0].proposal_id == test_proposal_id 
+    assert locked_proposals_list.locked_proposals[0].proposal_id == test_proposal_id
 
-
-    #unlocking
+    # unlocking
     data_unlock = {"proposals_to_change": [test_proposal_id]}
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
-        response_unlock = await ac.put( f"/v1/proposals/unlock",
-                json=data_unlock,headers={"Authorization": key.secret_key}) 
-        
+        response_unlock = await ac.put(
+            f"/v1/proposals/unlock",
+            json=data_unlock,
+            headers={"Authorization": key.secret_key},
+        )
+
     response_unlock_json = response_unlock.json()
     assert response_unlock.status_code == 200
     unlocked_proposals_info = ProposalChangeResultsList(**response_unlock_json)
     assert unlocked_proposals_info.successful_proposals == [test_proposal_id]
-    proposal_objects = await proposal_service.fetch_proposals(proposal_id = [test_proposal_id])
+    proposal_objects = await proposal_service.fetch_proposals(
+        proposal_id=[test_proposal_id]
+    )
     assert proposal_objects[0].locked == False
+
 
 @pytest.mark.anyio
 async def test_lock_and_unlock_beamlines():
@@ -92,40 +106,54 @@ async def test_lock_and_unlock_beamlines():
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
-        response_start = await ac.put( f"/v1/proposals/beamline/unlock/{test_beamline_name}",headers={"Authorization": key.secret_key})
-    
+        response_start = await ac.put(
+            f"/v1/proposals/beamline/unlock/{test_beamline_name}",
+            headers={"Authorization": key.secret_key},
+        )
+
     response_start_json = response_start.json()
     assert response_start.status_code == 200
     start_beamline_info = ProposalChangeResultsList(**response_start_json)
     assert start_beamline_info.successful_proposals == [test_proposal_id]
-    proposal_objects = await proposal_service.fetch_proposals(proposal_id = [test_proposal_id])
+    proposal_objects = await proposal_service.fetch_proposals(
+        proposal_id=[test_proposal_id]
+    )
     assert proposal_objects[0].locked == False
-
 
     # lock beamline
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
-        response_lock = await ac.put( f"/v1/proposals/beamline/lock/{test_beamline_name}",headers={"Authorization": key.secret_key})
-    
+        response_lock = await ac.put(
+            f"/v1/proposals/beamline/lock/{test_beamline_name}",
+            headers={"Authorization": key.secret_key},
+        )
+
     response_lock_json = response_lock.json()
     assert response_lock.status_code == 200
     locked_beamline_info = ProposalChangeResultsList(**response_lock_json)
     assert locked_beamline_info.successful_proposals == [test_proposal_id]
-    proposal_objects = await proposal_service.fetch_proposals(proposal_id = [test_proposal_id])
+    proposal_objects = await proposal_service.fetch_proposals(
+        proposal_id=[test_proposal_id]
+    )
     assert proposal_objects[0].locked == True
 
-    #unlock beamline 
+    # unlock beamline
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
-        response_unlock = await ac.put( f"/v1/proposals/beamline/unlock/{test_beamline_name}",headers={"Authorization": key.secret_key})
-    
+        response_unlock = await ac.put(
+            f"/v1/proposals/beamline/unlock/{test_beamline_name}",
+            headers={"Authorization": key.secret_key},
+        )
+
     response_unlock_json = response_unlock.json()
     assert response_unlock.status_code == 200
     unlocked_beamline_info = ProposalChangeResultsList(**response_unlock_json)
     assert unlocked_beamline_info.successful_proposals == [test_proposal_id]
-    proposal_objects = await proposal_service.fetch_proposals(proposal_id = [test_proposal_id])
+    proposal_objects = await proposal_service.fetch_proposals(
+        proposal_id=[test_proposal_id]
+    )
     assert proposal_objects[0].locked == False
 
 
@@ -136,41 +164,52 @@ async def test_lock_and_unlock_cycles():
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
-        response_start = await ac.put( f"/v1/proposals/cycle/unlock/{test_cycle_name}/{facility}",headers={"Authorization": key.secret_key})
-    
+        response_start = await ac.put(
+            f"/v1/proposals/cycle/unlock/{test_cycle_name}/{facility}",
+            headers={"Authorization": key.secret_key},
+        )
+
     response_start_json = response_start.json()
     assert response_start.status_code == 200
     start_info = ProposalChangeResultsList(**response_start_json)
     assert start_info.successful_proposals == [test_proposal_id]
-    proposal_objects = await proposal_service.fetch_proposals(proposal_id = [test_proposal_id])
+    proposal_objects = await proposal_service.fetch_proposals(
+        proposal_id=[test_proposal_id]
+    )
     assert proposal_objects[0].locked == False
-
 
     # lock beamline
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
-        response_lock = await ac.put( f"/v1/proposals/cycle/lock/{test_cycle_name}/{facility}",headers={"Authorization": key.secret_key})
-    
+        response_lock = await ac.put(
+            f"/v1/proposals/cycle/lock/{test_cycle_name}/{facility}",
+            headers={"Authorization": key.secret_key},
+        )
+
     response_lock_json = response_lock.json()
     assert response_lock.status_code == 200
     locked_cycle_info = ProposalChangeResultsList(**response_lock_json)
     assert locked_cycle_info.successful_proposals == [test_proposal_id]
-    proposal_objects = await proposal_service.fetch_proposals(proposal_id = [test_proposal_id])
+    proposal_objects = await proposal_service.fetch_proposals(
+        proposal_id=[test_proposal_id]
+    )
     assert proposal_objects[0].locked == True
 
-    #unlock beamline 
+    # unlock beamline
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
-        response_unlock = await ac.put( f"/v1/proposals/cycle/unlock/{test_cycle_name}/{facility}",headers={"Authorization": key.secret_key})
-    
+        response_unlock = await ac.put(
+            f"/v1/proposals/cycle/unlock/{test_cycle_name}/{facility}",
+            headers={"Authorization": key.secret_key},
+        )
+
     response_unlock_json = response_unlock.json()
     assert response_unlock.status_code == 200
     unlocked_cycle_info = ProposalChangeResultsList(**response_unlock_json)
     assert unlocked_cycle_info.successful_proposals == [test_proposal_id]
-    proposal_objects = await proposal_service.fetch_proposals(proposal_id = [test_proposal_id])
+    proposal_objects = await proposal_service.fetch_proposals(
+        proposal_id=[test_proposal_id]
+    )
     assert proposal_objects[0].locked == False
-
-
-

--- a/src/nsls2api/tests/api/test_admin_api.py
+++ b/src/nsls2api/tests/api/test_admin_api.py
@@ -29,7 +29,7 @@ async def test_lock_and_unlock_proposals():
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
         response_start = await ac.put(
-            f"/v1/proposals/unlock",
+            f"/v1/admin/proposals/unlock",
             json=data_start,
             headers={"Authorization": key.secret_key},
         )
@@ -49,7 +49,7 @@ async def test_lock_and_unlock_proposals():
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
         response_lock = await ac.put(
-            f"/v1/proposals/lock",
+            f"/v1/admin/proposals/lock",
             json=data_lock,
             headers={"Authorization": key.secret_key},
         )
@@ -70,7 +70,7 @@ async def test_lock_and_unlock_proposals():
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
         response_get_list = await ac.get(
-            f"/v1/proposals/locked?beamline={beamline}&facility={facility_name}",
+            f"/v1/admin/proposals/locked?beamline={beamline}&facility={facility_name}",
             headers={"Authorization": key.secret_key},
         )
     response_get_list_json = response_get_list.json()
@@ -84,7 +84,7 @@ async def test_lock_and_unlock_proposals():
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
         response_unlock = await ac.put(
-            f"/v1/proposals/unlock",
+            f"/v1/admin/proposals/unlock",
             json=data_unlock,
             headers={"Authorization": key.secret_key},
         )
@@ -107,7 +107,7 @@ async def test_lock_and_unlock_beamlines():
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
         response_start = await ac.put(
-            f"/v1/proposals/beamline/unlock/{test_beamline_name}",
+            f"/v1/admin/proposals/beamline/unlock/{test_beamline_name}",
             headers={"Authorization": key.secret_key},
         )
 
@@ -125,7 +125,7 @@ async def test_lock_and_unlock_beamlines():
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
         response_lock = await ac.put(
-            f"/v1/proposals/beamline/lock/{test_beamline_name}",
+            f"/v1/admin/proposals/beamline/lock/{test_beamline_name}",
             headers={"Authorization": key.secret_key},
         )
 
@@ -143,7 +143,7 @@ async def test_lock_and_unlock_beamlines():
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
         response_unlock = await ac.put(
-            f"/v1/proposals/beamline/unlock/{test_beamline_name}",
+            f"/v1/admin/proposals/beamline/unlock/{test_beamline_name}",
             headers={"Authorization": key.secret_key},
         )
 
@@ -165,7 +165,7 @@ async def test_lock_and_unlock_cycles():
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
         response_start = await ac.put(
-            f"/v1/proposals/cycle/unlock/{test_cycle_name}/{facility}",
+            f"/v1/admin/proposals/cycle/unlock/{test_cycle_name}/{facility}",
             headers={"Authorization": key.secret_key},
         )
 
@@ -183,7 +183,7 @@ async def test_lock_and_unlock_cycles():
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
         response_lock = await ac.put(
-            f"/v1/proposals/cycle/lock/{test_cycle_name}/{facility}",
+            f"/v1/admin/proposals/cycle/lock/{test_cycle_name}/{facility}",
             headers={"Authorization": key.secret_key},
         )
 
@@ -201,7 +201,7 @@ async def test_lock_and_unlock_cycles():
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
         response_unlock = await ac.put(
-            f"/v1/proposals/cycle/unlock/{test_cycle_name}/{facility}",
+            f"/v1/admin/proposals/cycle/unlock/{test_cycle_name}/{facility}",
             headers={"Authorization": key.secret_key},
         )
 

--- a/src/nsls2api/tests/api/test_admin_api.py
+++ b/src/nsls2api/tests/api/test_admin_api.py
@@ -1,15 +1,14 @@
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from nsls2api.main import app
 from nsls2api.api.models.proposal_model import (
-    ProposalChangeResultsList,
     LockedProposalsList,
-    ProposalFullDetailsList,
+    ProposalChangeResultsList,
 )
-from nsls2api.services import proposal_service
+from nsls2api.main import app
 from nsls2api.models.apikeys import ApiKey
-import os
+from nsls2api.services import proposal_service
 
 test_proposal_id = "314159"
 
@@ -29,7 +28,7 @@ async def test_lock_and_unlock_proposals():
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
         response_start = await ac.put(
-            f"/v1/admin/proposals/unlock",
+            "/v1/admin/proposals/unlock",
             json=data_start,
             headers={"Authorization": key.secret_key},
         )
@@ -49,7 +48,7 @@ async def test_lock_and_unlock_proposals():
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
         response_lock = await ac.put(
-            f"/v1/admin/proposals/lock",
+            "/v1/admin/proposals/lock",
             json=data_lock,
             headers={"Authorization": key.secret_key},
         )
@@ -84,7 +83,7 @@ async def test_lock_and_unlock_proposals():
         transport=ASGITransport(app=app), base_url="http://test"
     ) as ac:
         response_unlock = await ac.put(
-            f"/v1/admin/proposals/unlock",
+            "/v1/admin/proposals/unlock",
             json=data_unlock,
             headers={"Authorization": key.secret_key},
         )


### PR DESCRIPTION
The proposal locking endpoints are really an administrative function and so they are moved under the `/admin` path. 