### PR TITLE
test: Update test that expects CDI to be missing

### DIFF
--- a/integration-tests/check_all_beamlines.http
+++ b/integration-tests/check_all_beamlines.http
@@ -33,14 +33,14 @@ Accept: application/json
     });
 %}
 
-### Check CDI Details
-# @name = cdi-details
-GET http://{{host}}/v1/beamline/cdi
+### Check Non-existent Beamline Details
+# @name = zzz-details
+GET http://{{host}}/v1/beamline/zzz
 Accept: application/json
 
 > {%
     client.test("Request executed successfully", function () {
-        client.assert(response.status === 404, "CDI should not exist yet!");
+        client.assert(response.status === 404, "ZZZ should not exist!");
     });
 %}
 


### PR DESCRIPTION
A unit test used "CDI" to test what happens when someone asks for a nonexistent beamline. Now that we need to actually _add_ CDI, this is not a good test. I chose "ZZZ" as a new non-existent beamline name, in hope that no one will create a future beamline with a sleepy name.