### PR TITLE
Template notation in GHA conditional

### DIFF
--- a/.github/workflows/data-consistency-workflow.yml
+++ b/.github/workflows/data-consistency-workflow.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   integration_tests:
-    if: ${{ github.repository == "nsls2/nsls2api" }}  # Do not run on forks
+    if: ${{ github.repository == 'nsls2/nsls2api' }}  # Do not run on forks
     runs-on: self-hosted
 
     steps:

--- a/.github/workflows/test-dev-deployment.yml
+++ b/.github/workflows/test-dev-deployment.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   integration_tests:
-    if: ${{ github.repository == "nsls2/nsls2api" }}  # Do not run on forks
+    if: ${{ github.repository == 'nsls2/nsls2api' }}  # Do not run on forks
     runs-on: self-hosted
 
     steps:

--- a/.github/workflows/test-production-deployment.yml
+++ b/.github/workflows/test-production-deployment.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   integration_tests:
-    if: ${{ github.repository == "nsls2/nsls2api" }}  # Do not run on forks
+    if: ${{ github.repository == 'nsls2/nsls2api' }}  # Do not run on forks
     runs-on: self-hosted
 
     steps:


### PR DESCRIPTION
Fixes #218
Prohibit GHA self-hosted runners on forked repos

Checks that self-host runners for integration tests are only allowed for the NSLS2 repo. Do not run on public forks.