### PR TITLE
Update apt-get in CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,9 @@ jobs:
 
       # Install Kerberos dependencies (for N2SNUserTools)
       - name: Install krb5-devel
-        run: sudo apt-get -y install libkrb5-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install libkrb5-dev
 
       - name: Setup Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
CI has been [failing to start recently](https://github.com/AditiChikkali/nsls2api/actions/runs/30364677615/job/90311742953?pr=1) because the runner's apt-get database was outdated.


Now we update the db before attempting to install the package, per typical usage.

This fix was [tested on a separate branch](https://github.com/NSLS2/nsls2api/actions/runs/30499965440/job/90737246840?pr=259) with other (unrelated) changes.
